### PR TITLE
Remove literals from join projections

### DIFF
--- a/src/facts/list.rs
+++ b/src/facts/list.rs
@@ -31,15 +31,13 @@ impl FactContainer for FactList {
         }
     }
 
-    fn join<'a>(&'a self, other: &'a Self, arity: usize, projections: &[&[Result<usize, String>]]) -> Vec<FactLSM<Self>> {
+    fn join<'a>(&'a self, other: &'a Self, arity: usize, projections: &[&[usize]]) -> Vec<FactLSM<Self>> {
 
         let mut builders: Vec<FactBuilder<Self>> = vec![FactBuilder::default(); projections.len()];
 
         let mut action = |v1: <Facts as Container>::Ref<'_>, v2: <Facts as Container>::Ref<'_>| {
             for (projection, builder) in projections.iter().zip(builders.iter_mut()) {
-                builder.push(projection.iter().map(|i| {
-                    match i { Ok(col) => if *col < v1.len() { v1.get(*col).as_slice() } else { v2.get(*col - v1.len()).as_slice() },
-                            Err(lit) => lit.as_bytes() }}));
+                builder.push(projection.iter().map(|col| if *col < v1.len() { v1.get(*col).as_slice() } else { v2.get(*col - v1.len()).as_slice() }));
             }
         };
 

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -213,11 +213,11 @@ pub trait FactContainer : Form + Length + Merge + Default + Sized {
     /// Applies an action to each contained fact.
     fn apply<'a>(&'a self, action: impl FnMut(&[<Terms as Container>::Ref<'a>]));
     /// Joins `self` and `other` on the first `arity` columns, putting projected results in `builders`.
-    fn join<'a>(&'a self, other: &'a Self, arity: usize, projections: &[&[Result<usize, String>]]) -> Vec<FactLSM<Self>> ;
+    fn join<'a>(&'a self, other: &'a Self, arity: usize, projections: &[&[usize]]) -> Vec<FactLSM<Self>> ;
     /// Joins `self` and `others` on the first `arity` columns, putting projected results in `builders`.
     ///
     /// The default implementation processes `others` in order, but more thoughtful implementations exist.
-    fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projections: &[&[Result<usize, String>]]) -> Vec<FactLSM<Self>> {
+    fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projections: &[&[usize]]) -> Vec<FactLSM<Self>> {
         let mut results = (0 .. projections.len()).map(|_| FactLSM::default()).collect::<Vec<_>>();
         for other in others {
             let builts = self.join(other, arity, projections);

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -233,7 +233,7 @@ fn join_help<'a, const K: usize>(
     this: Vec<<Lists<Vec<[u8; K]>> as Container>::Borrowed<'a>>,
     that: Vec<<Lists<Vec<[u8; K]>> as Container>::Borrowed<'a>>,
     arity: usize,
-    projections: &[&[Result<usize, String>]],
+    projections: &[&[usize]],
 ) -> Vec<FactLSM<Forest<Terms>>> {
 
     if projections.is_empty() { return Vec::default(); }
@@ -265,15 +265,12 @@ fn join_help<'a, const K: usize>(
                 for idx1 in 0 .. count1 {
                     let ext1 = &extensions1[idx1 * width1 ..][.. width1];
                     for (projection, builder) in projections.iter().zip(builders.iter_mut()) {
-                        builder.push(projection.iter().map(|i| match i {
-                            Ok(col) => {
-                                if *col < arity { prefix[*col] }
-                                else if *col < arity + width0 { ext0[col - arity] }
-                                else if *col < arity + width0 + arity { prefix[*col - arity - width0] }
-                                else { ext1[col - width0 - arity - arity] }
-                            }
-                            Err(lit) => lit.as_bytes()
-                        }));
+                        builder.push(projection.iter().map(|col|
+                            if *col < arity { prefix[*col] }
+                            else if *col < arity + width0 { ext0[col - arity] }
+                            else if *col < arity + width0 + arity { prefix[*col - arity - width0] }
+                            else { ext1[col - width0 - arity - arity] }
+                        ));
                     }
                 }
             }
@@ -340,7 +337,7 @@ impl FactContainer for Forest<Terms> {
         if self.len() > 0 { apply(&self.borrow()[..], 0, action); }
     }
 
-    fn join<'a>(&'a self, other: &'a Self, arity: usize, projections: &[&[Result<usize, String>]]) -> Vec<FactLSM<Self>> {
+    fn join<'a>(&'a self, other: &'a Self, arity: usize, projections: &[&[usize]]) -> Vec<FactLSM<Self>> {
 
         if self.layers.len() < arity || other.layers.len() < arity {
             assert!(self.len() == 0 || other.len() == 0);
@@ -383,15 +380,12 @@ impl FactContainer for Forest<Terms> {
                     for idx1 in 0 .. count1 {
                         let ext1 = &extensions1[idx1 * width1 ..][.. width1];
                         for (projection, builder) in projections.iter().zip(builders.iter_mut()) {
-                            builder.push(projection.iter().map(|i| match i {
-                                Ok(col) => {
-                                    if *col < arity { prefix[*col].as_slice() }
-                                    else if *col < arity + width0 { ext0[col - arity].as_slice() }
-                                    else if *col < arity + width0 + arity { prefix[*col - arity - width0].as_slice() }
-                                    else { ext1[col - width0 - arity - arity].as_slice() }
-                                }
-                                Err(lit) => lit.as_bytes()
-                            }));
+                            builder.push(projection.iter().map(|col|
+                                if *col < arity { prefix[*col].as_slice() }
+                                else if *col < arity + width0 { ext0[col - arity].as_slice() }
+                                else if *col < arity + width0 + arity { prefix[*col - arity - width0].as_slice() }
+                                else { ext1[col - width0 - arity - arity].as_slice() }
+                            ));
                         }
                     }
                 }

--- a/src/join.rs
+++ b/src/join.rs
@@ -11,7 +11,7 @@ pub fn join_with<F: FactContainer + Clone>(
     body2: &FactSet<F>,
     stable: bool,
     arity: usize,
-    projections: &[&[Result<usize, String>]],
+    projections: &[&[usize]],
 ) -> Vec<FactLSM<F>>
 {
     let mut lsms = vec![FactLSM::default(); projections.len()];


### PR DESCRIPTION
Join projections could by either column references or literals, as finishing actions for rule heads need the ability to insert literals (and repeated columns). In both cases, literals and repeated columns, the column values can be stitched in later and needn't gum up the tuple sorting and trie formation logic. This also unlocks some optimization where we now know that the produced facts will retain the types of their inputs, e.g. if they are `[u8; K]`.

The combined effect seems to be a ~20% improvement for GALEN, from ~18s down to ~15s. Both commits contribute, the first simplifying the inner loop by removing the literal test, and the second using fixed sized records in fact formation.

The code to efficiently stitch in literals or duplicate columns hasn't been written yet, and it does something inefficient instead. The plan is to soon rip out the list representation and go all in on columnar tries, as well as ripping out the current planner, and once these have happened feels like a good time to write that code (vs now, where the hard part will be accommodating the vestigial implementations).