### PR TITLE
New planning framework

### DIFF
--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -498,11 +498,9 @@ impl<const K: usize> Forest<Vec<[u8; K]>> {
         for i in 0 .. W { layers[i].list.values.push(facts[0][i]); }
         for i in 1 .. facts.len() {
             if facts[i] != facts[i-1] {
-                let common = facts[i].iter().zip(facts[i-1].iter()).position(|(i0, i1)| i0 != i1);
-                if let Some(pos) = common {
-                    for to_seal in pos+1 .. W { layers[to_seal].list.bounds.push(layers[to_seal].list.values.len() as u64); }
-                    for to_push in pos   .. W { layers[to_push].list.values.push(facts[i][to_push]); }
-                }
+                let pos = facts[i].iter().zip(facts[i-1].iter()).position(|(i0, i1)| i0 != i1).unwrap();
+                for to_seal in pos+1 .. W { layers[to_seal].list.bounds.push(layers[to_seal].list.values.len() as u64); }
+                for to_push in pos   .. W { layers[to_push].list.values.push(facts[i][to_push]); }
             }
         }
 


### PR DESCRIPTION
This PR removes the existing planning framework that operates in terms of stateful binary joins, and introduces one that works in terms of several stateless pipelines. Stateful binary joins still exist, in that one can write binary rules and each of these should be rendered at parity with the previous planner, but the planner will not approach many-atom rules by trying to create trees of binary joins. A future planner could do both, but for the moment we are going to try and reach out to build the innards we'll need (multiway joins that are optionally stateful).

As an example of what happens, imagine a join A ⨝ B ⨝ C on some different keys. While the initial join can be done a few ways (and not much thought is done here), when they experience changes dA, dB, and dC we'll want to think more specifically about how to perform the updates to do work proportional to the changes, rather than the whole inputs. We frame the update process for the whole rule as the sum of updates for each atom:

dA ⨝ B ⨝ C +
dB ⨝ A ⨝ C + 
dC ⨝ B ⨝ A

We could plan each ⨝ generally, but practically we want to be sure to consider starting from the d-terms, as they have the potential to be arbitrarily smaller than the other relations (but aren't required to be). This framing allows us to determine the results from these pipelines, without *maintaining* the pipelines across updates. The new intermediate facts they produce are transient, and while we still need to manipulate them they can be discarded once used.

The plans for each d-term are a sequence of pairs `{ atom } x { term }` of atoms and terms, where each indicates that we should add the indicated terms by way of the indicated atoms. This seems superficially similar to [FreeJoin](https://arxiv.org/abs/2301.10841), which also aims to unify atom-at-a-time joins with worst-case-optimal joins (one form of which is term-at-a-time joins). The planner has an atom-at-a-time flavor and a term-at-a-time flavor, and does some optimizations like fusing runs with the same atoms. The intent is only to leave the door open for better term-at-a-time implementations; right now they panic, and while there are standard count/propose/validate patterns to use they require a bit more coding.