### PR TITLE
Use columns for join working state

### DIFF
--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -392,11 +392,11 @@ pub mod terms {
                 else if column < this.len() {
                     // We expect this to be the next column in `this_values`.
                     let values = this_values[this_cursor];
+                    this_cursor += 1;
 
                     // Expand `this_i`, and corresponding repetitions in `groups` and `that_j`.
-                    if !last { that_j = this_i.iter().zip(that_j.iter()).flat_map(|(i,j)| { let (l,u) = values.bounds.bounds(*i); (l .. u).map(move |_| *j) }).collect(); }
+                    if that_cursor < that_values.len() { that_j = this_i.iter().zip(that_j.iter()).flat_map(|(i,j)| { let (l,u) = values.bounds.bounds(*i); (l .. u).map(move |_| *j) }).collect(); }
                     (groups, this_i) = groups.into_iter().zip(this_i.iter().copied()).flat_map(|(g,i)| { let (l,u) = values.bounds.bounds(i); (l .. u).map(move |i| (g, i)) }).unzip();
-                    this_cursor += 1;
                     sort_terms(values, &mut groups, &this_i, last)
                 }
                 else if column < this.len() + arity {
@@ -405,11 +405,11 @@ pub mod terms {
                 else {
                     // We expect this to be the next column in `that_values`.
                     let values = that_values[that_cursor];
+                    that_cursor += 1;
 
                     // Expand `that_j`, and corresponding repetitions in `groups` and `this_i`.
-                    if !last { this_i = this_i.iter().zip(that_j.iter()).flat_map(|(i,j)| { let (l,u) = values.bounds.bounds(*j); (l .. u).map(move |_| *i) }).collect(); }
+                    if this_cursor < this_values.len() { this_i = this_i.iter().zip(that_j.iter()).flat_map(|(i,j)| { let (l,u) = values.bounds.bounds(*j); (l .. u).map(move |_| *i) }).collect(); }
                     (groups, that_j) = groups.into_iter().zip(that_j.iter().copied()).flat_map(|(g,j)| { let (l,u) = values.bounds.bounds(j); (l .. u).map(move |j| (g, j)) }).unzip();
-                    that_cursor += 1;
                     sort_terms(values, &mut groups, &that_j, last)
                 };
 


### PR DESCRIPTION
The columnar join working state is a list of integer triples `(group, this_i, that_j)` indicating indexes `this_i` and `that_j` which need to be cross joined, and a `group` identifier that indicates how the results should be ordered and grouped. They currently (pre-PR) exist as two lists of pairs, with one of the integers redundant at any time.

The PR proposes splitting the triples out into three columns, specifically,
1. splitting `tojoin` into `this_i` and `that_j` columns,
2. extracting the `group` column from the current list of pairs (the second column of which is always either `this_i` or `that_j`).

The first is a small localized change; the second touches columnar sorting which is used by others, though their use has the same behavior: group information and index information can be presented as independent columns.
