### PR TITLE
Join rework

### DIFF
--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -160,7 +160,7 @@ pub trait FactContainer : Length + Merge + Default + Sized + Clone {
     /// Applies an action to the facts, building the corresponding output.
     fn act_on(&self, action: &Action<String>) -> FactLSM<Self>;
     /// Joins `self` and `other` on the first `arity` columns, putting projected results in `builders`.
-    fn join<'a>(&'a self, other: &'a Self, arity: usize, projection: &[usize]) -> FactLSM<Self>;
+    fn join<'a>(&'a self, other: &'a Self, arity: usize, projection: &[usize]) -> FactLSM<Self> { self.join_many([other].into_iter(), arity, projection) }
     /// The subset of `self` whose facts do not start with any prefix in `others`.
     fn antijoin<'a>(self, _others: impl Iterator<Item = &'a Self>) -> Self where Self: 'a { unimplemented!() }
     /// The subset of `self` whose facts start with some prefix in `others`.
@@ -171,9 +171,7 @@ pub trait FactContainer : Length + Merge + Default + Sized + Clone {
     /// The default implementation processes `others` in order, but more thoughtful implementations exist.
     fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projection: &[usize]) -> FactLSM<Self> {
         let mut result = FactLSM::default();
-        for other in others {
-            result.extend(&mut self.join(other, arity, projection));
-        }
+        for other in others { result.extend(&mut self.join(other, arity, projection)); }
         result
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -44,7 +44,7 @@ fn implement_action(head: &[Atom], body: &Atom, stable: bool, facts: &mut Relati
 /// The complicated implementation case where these is at least one join.
 fn implement_joins(head: &[Atom], body: &[Atom], stable: bool, facts: &mut Relations) {
 
-    let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body);
+    let (plans, loads) = plan::plan_rule::<plan::ByAtom>(head, body);
 
     let plan_atoms = if stable { 1 } else { body.len() };
 


### PR DESCRIPTION
This PR reworks `join_cols` to support multiple `that` inputs, essentially supporting `A join Sum_i Bi` as one operation.

This special operator has the advantage that it can perform the summation over i at a moment halfway through the join, once we have identified a semijoin each `Bi` but before we have expanded them out. This performs the sum at terms that are no more than the input `Bi`, nor the output `A join Bi`.

Empirically, this speeds things up by various amounts over different problems. The GALEN example went from ~14.25s to ~13.75s. Others are within the margin of error. Presumably it depends on how much time we are spending merging, and whether the inputs are that much smaller than the outputs.

Other improvements in the vicinity, for example recognizing `0 ..` prefixes of projections when performing the permute/subset transformation. These prefixes can be extracted in order, without sorting.