### PR TITLE
Introduce abstract relations

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -92,7 +92,6 @@ fn parse_atom<I: Iterator<Item=Token>>(tokens: &mut Peekable<I>) -> Option<Atom>
 
     // Names starting with an `!` indicate an antijoin, which suppresses records that match.
     let (anti, name) = name.strip_prefix("!").map(|n| (true, n)).unwrap_or((false, name.as_str()));
-    if anti { panic!("antijoins ('!') not correctly supported yet"); }
 
     Some(Atom { name: name.to_owned(), anti, terms })
 }


### PR DESCRIPTION
This PR is work on the path towards maintaining "abstract relations", relations that go beyond a pile of facts and towards support for e.g. antijoins and function.

Informally, the observation is that the way we interact with atoms in planning and execution is largely through an understanding of terms present in an atom, the terms that are groundable as a function of other ground terms, and the actions that implement this grounding. For example,
1. A relation with three columns can produce any of those columns in response to any subset of the columns being fixed.
2. A relation that is defined as the complement of another relation with three columns cannot produce ground values for any of its columns, no matter which other of its columns are ground. If provided values for all columns, it can accept or reject the fact, though.
3. A relation that is defined by function logic, perhaps `range(a, b, c)` indicating `a <= b < c`, can ground some terms as a function of other terms, for example `b` as a function of `(a, c)` but neither of `a` nor `c` as a function of the other two.

This grounding information is sufficient to pilot a planner through the involved relations, ensuring that we introduce ground terms and then validate against all relations, but do not accidentally rely on an atom that cannot ground a term to do so.

On the execution side, atoms need to be able to produce for any set of ground terms a count of the number of distinct values of a groundable term it would propose, and to perform the proposal (join) and validate other proposals (semijoin, but .. in this PR also join). As above, we can generalize from relations that are piles of data to relations that are antijoins, or relations defined by function logic.

The load-bearing abstractions as of the first commit at least are `PlanAtom<T>` and `ExecAtom<T>`, indicating things that can respectively be planned and executed for some term type `T`.