### PR TITLE
Get much of FlowLog eval working

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,7 @@ pub mod types {
         pub fn push(&mut self, rule: Rule) {
             if rule.body.is_empty() {
                 for atom in rule.head.iter() {
-                    use columnar::{Container, Push};
+                    use columnar::Push;
                     use crate::facts::{Forest, Terms};
                     let mut lits = Vec::with_capacity(atom.terms.len());
                     for term in atom.terms.iter() {
@@ -78,7 +78,7 @@ pub mod types {
                             continue;
                         }
                     }
-                    let facts = Forest::<Terms>::from_columns(&lits.iter().map(|l| l.borrow()).collect::<Vec<_>>()[..]);
+                    let facts = Forest::<Terms>::from_columns(lits);
                     self.facts
                         .entry(atom.name.to_owned())
                         .extend([facts]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,6 @@ use std::io::{BufReader, BufRead};
 
 use datatoad::{parse, types};
 
-
-
 fn main() {
 
     let mut state = types::State::default();
@@ -49,6 +47,44 @@ fn handle_command(text: &str, state: &mut types::State, timer: &mut std::time::I
             match word {
                 ".exec" => { for filename in words { exec_file(filename, state, timer); } }
                 ".list" => { state.facts.list() }
+                ".flow" => {
+
+                    use std::io::{BufRead, BufReader};
+                    use std::fs::File;
+
+                    let args: Result<[_;3],_> = words.take(3).collect::<Vec<_>>().try_into();
+                    if let Ok(args) = args {
+                        let name = args[0].to_string();
+                        let arity = args[1].len();
+                        let filename = args[2];
+                        if let Ok(file) = File::open(filename) {
+                            let mut file = BufReader::new(file);
+                            use columnar::Push;
+                            use datatoad::facts::{Forest, Terms};
+                            let mut columns = vec![Terms::default(); arity];
+                            let mut readline = String::default();
+                            while file.read_line(&mut readline).unwrap() > 0 {
+                                let line = readline.trim();
+                                for (term, col) in line.split(',').zip(columns.iter_mut()) {
+                                    col.push(&term.parse::<u32>().unwrap().to_be_bytes());
+                                }
+                                readline.clear();
+                                use columnar::Len;
+                                if columns[0].len() > 100_000_000 {
+                                    // Pass ownership of columns so the method can drop them as they are processed.
+                                    let trie = Forest::from_columns(columns);
+                                    state.facts.entry(name.clone()).extend([trie]);
+                                    columns = vec![Terms::default(); arity];
+                                }
+                            }
+                            let trie = Forest::from_columns(columns);
+                            state.facts.entry(name).extend([trie]);
+                            state.update();
+                        }
+                        else { println!("file not found: {:?}", filename); }
+                    }
+                    else { println!(".flow command requires arguments: <name> <patt> <file>"); }
+                }
                 ".load" => {
 
                     use std::io::{BufRead, BufReader};
@@ -63,12 +99,14 @@ fn handle_command(text: &str, state: &mut types::State, timer: &mut std::time::I
                         if let Ok(regex) = regex::Regex::new(pattern) {
                             let names = regex.capture_names().map(|x| x.to_owned()).collect::<Vec<_>>();
                             if let Ok(file) = File::open(filename) {
-                                let file = BufReader::new(file);
-                                use columnar::{Container, Push};
+                                let mut file = BufReader::new(file);
+                                use columnar::Push;
                                 use datatoad::facts::{Forest, Terms};
-                                let mut columns = vec![Terms::default(); names.len()-1];
-                                for readline in file.lines() {
-                                    let line = readline.expect("read error");
+                                let arity = names.len()-1;
+                                let mut columns = vec![Terms::default(); arity];
+                                let mut readline = String::default();
+                                while file.read_line(&mut readline).unwrap() > 0 {
+                                    let line = readline.trim();
                                     if let Some(captures) = regex.captures(&line) {
                                         for ((term, name), col) in captures.iter().zip(names.iter()).skip(1).zip(columns.iter_mut()) {
                                             let term = term.unwrap().as_str();
@@ -80,8 +118,16 @@ fn handle_command(text: &str, state: &mut types::State, timer: &mut std::time::I
                                             }
                                         }
                                     }
+                                    readline.clear();
+                                    use columnar::Len;
+                                    if columns[0].len() > 100_000_000 {
+                                        // Pass ownership of columns so the method can drop them as they are processed.
+                                        let trie = Forest::from_columns(columns);
+                                        state.facts.entry(name.clone()).extend([trie]);
+                                        columns = vec![Terms::default(); arity];
+                                    }
                                 }
-                                let trie = Forest::from_columns(&columns.iter().map(|c| c.borrow()).collect::<Vec<_>>()[..]);
+                                let trie = Forest::from_columns(columns);
                                 state.facts.entry(name).extend([trie]);
                                 state.update();
                             }
@@ -91,12 +137,13 @@ fn handle_command(text: &str, state: &mut types::State, timer: &mut std::time::I
                     }
                     else { println!(".load command requires arguments: <name> <patt> <file>"); }
                 }
-                ".save" => { println!("unimplemnted: {:?}", word); }
-                ".time" => { *timer = std::time::Instant::now(); }
-                ".wipe" => { *state = Default::default(); }
-                _ => {
-                    println!("Parse failure: {:?}", text);
+                ".save" => { println!("unimplemented: {:?}", word); }
+                ".time" => {
+                    println!("time:\t{:?}\t{:?}", timer.elapsed(), words.collect::<Vec<_>>());
+                    *timer = std::time::Instant::now();
                 }
+                ".wipe" => { *state = Default::default(); }
+                _ => { println!("Parse failure: {:?}", text); }
             }
         }
     }


### PR DESCRIPTION
Several classes of edit that are hard to tease apart, in support of getting the [FlowLog](https://arxiv.org/abs/2511.00865) evaluation up and running.

0. Specialized `.flow` data loading for CSV data with `u32` fields.
1. Pass ownership of columns to `Forest::from_columns` in order to allow them to be dropped as columns are formed.
2. Specialize `from_columns` in `Forest<Terms>` in order to access optimized column sorting.
3. Form output every 100M rows in file ingestion, to break up the work and the overheads.
4. Form output every 100M rows in join implementation, to break up the work and the overheads.