### PR TITLE
Introduce paged radix sort

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -200,71 +200,87 @@ mod flow_log {
             let file = std::io::BufReader::new(file);
             let mut reader = simd_csv::ZeroCopyReaderBuilder::default().has_headers(false).from_reader(file);
             if let Some(record) = reader.read_byte_record().unwrap() {
-                let arity = record.len();
-                let mut bytes = Vec::default();
-                for term in record.iter() {
-                    let num = term.iter().fold(0u32, |n,b| n*10 + ((b-48) as u32));
-                    bytes.extend(num.to_be_bytes());
-                }
-
-                let atom = crate::types::Atom { name: name.to_string(), anti: false, terms: vec![crate::types::Term::Lit(vec![]); arity] };
-
-                while let Some(record) = reader.read_byte_record().unwrap() {
-                    for term in record.iter() {
-                        let num = term.iter().fold(0u32, |n,b| n*10 + ((b-48) as u32));
-                        bytes.extend(num.to_be_bytes());
-                    }
-                    if bytes.len() >= 4_000_000_000 {
-                        facts.entry(&atom).extend([to_forest(&mut bytes, arity)]);
-                        bytes.clear();
-                    }
-                }
-
-                facts.entry(&atom).extend([to_forest(&mut bytes, arity)]);
+                let first = record.iter().flat_map(|term| term.iter().fold(0u32, |n,b| n*10 + ((b-48) as u32)).to_be_bytes()).collect::<Vec<_>>();
+                let atom = crate::types::Atom { name: name.to_string(), anti: false, terms: vec![crate::types::Term::Lit(vec![]); first.len()/4] };
+                let data = match first.len()/4 {
+                    0 => { to_facts::<_, 0>(reader, first) },
+                    1 => { to_facts::<_, 4>(reader, first) },
+                    2 => { to_facts::<_, 8>(reader, first) },
+                    3 => { to_facts::<_,12>(reader, first) },
+                    4 => { to_facts::<_,16>(reader, first) },
+                    5 => { to_facts::<_,20>(reader, first) },
+                    6 => { to_facts::<_,24>(reader, first) },
+                    7 => { to_facts::<_,28>(reader, first) },
+                    8 => { to_facts::<_,32>(reader, first) },
+                    9 => { to_facts::<_,36>(reader, first) },
+                    _ => { unimplemented!("too many columns! (use `load_cols`)") }
+                };
+                facts.entry(&atom).extend(data);
             }
         }
         else { println!("file not found: {:?}", filename); }
     }
 
-    use datatoad::facts::{Forest, Lists, Terms, trie::Layer};
+    use datatoad::facts::{FactLSM, Forest, Lists, Terms, trie::Layer};
+    use datatoad::facts::radix_sort::{lsb_paged, PageBuilder};
 
-    /// Extracts a forest over `[u8;4]` values from bytes and a row arity.
-    ///
-    /// Only specialized up through arity nine; greater arities cause a panic.
-    fn to_forest(bytes: &mut [u8], arity: usize) -> Forest<Terms> {
-        let layers = match arity {
-            0 => { flow_sort::< 0>(bytes) },
-            1 => { flow_sort::< 4>(bytes) },
-            2 => { flow_sort::< 8>(bytes) },
-            3 => { flow_sort::<12>(bytes) },
-            4 => { flow_sort::<16>(bytes) },
-            5 => { flow_sort::<20>(bytes) },
-            6 => { flow_sort::<24>(bytes) },
-            7 => { flow_sort::<28>(bytes) },
-            8 => { flow_sort::<32>(bytes) },
-            9 => { flow_sort::<36>(bytes) },
-            _ => { unimplemented!("Too many columns") }
-        }.unwrap();
-        layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: l }) ).collect::<Vec<_>>().try_into().unwrap()
+    /// Converts a CSV reader into a collection of facts, provided `KW` the bytes per whole record.
+    fn to_facts<R: std::io::Read, const KW: usize>(mut reader: simd_csv::ZeroCopyReader<R>, bytes: Vec<u8>) -> FactLSM<Forest<Terms>> {
+        let mut array: [u8; KW] = bytes.try_into().unwrap();
+        let mut builder = PageBuilder::<[u8;KW], KW>::new(1024);
+        let mut counter = 0;
+        let mut result = FactLSM::default();
+        builder.push(array);
+        counter += 1;
+        while let Some(record) = reader.read_byte_record().unwrap() {
+
+            let mut iter = record.iter();
+            for index in 0 .. KW/4 {
+                let next = iter.next().unwrap().iter().fold(0u32, |n,b| n*10 + ((b-48) as u32)).to_be_bytes();
+                array[4*index .. 4*index+4].copy_from_slice(&next);
+            }
+            builder.push(array);
+            counter += 1;
+
+            if counter * KW >= 4_000_000_000 {
+                let (mut data, diff) = builder.done();
+                builder = PageBuilder::<[u8;KW], KW>::new(1024);
+                lsb_paged(&mut data, &diff[..]);
+                let iter = data.into_iter().flat_map(|page| page);
+                if let Some(layers) = build(iter) {
+                    result.push(layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: l }) ).collect::<Vec<_>>().try_into().unwrap());
+                }
+                counter = 0;
+            }
+        }
+
+        let (mut data, diff) = builder.done();
+        lsb_paged(&mut data, &diff[..]);
+        let iter = data.into_iter().flat_map(|page| page);
+        if let Some(layers) = build(iter) {
+            result.push(layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: l }) ).collect::<Vec<_>>().try_into().unwrap());
+        }
+
+        result
     }
 
-    /// Takes bytes blocked as `KW` bytes of `[u8;4]` values for each row, and builds layers.
-    fn flow_sort<const KW: usize>(entries: &mut [u8]) -> Option<Vec<Lists<Terms>>> {
+    /// Constructs a list of layers corresponding to `KW/4` columns of `[u8;4]` terms.
+    ///
+    /// Returns `None` only when the iterator is empty.
+    fn build<const KW: usize>(mut iter: impl Iterator<Item=[u8;KW]>) -> Option<Vec<Lists<Terms>>> {
 
-        use datatoad::facts::radix_sort;
-        use columnar::{Push, Len};
+        use columnar::{Len, Push};
 
-        radix_sort::lsb_range(entries.as_chunks_mut::<KW>().0, 0, KW);
-
-        let mut iter = entries.as_chunks_mut::<4>().0.chunks(KW/4);
         if let Some(row) = iter.next() {
             let mut columns: Vec<Lists<Terms>> = vec![Default::default(); KW/4];
-            for col in 0 .. KW/4 { columns[col].values.push(row[col]); }
+            let cols = row.as_chunks::<4>().0;
+            for col in 0 .. KW/4 { columns[col].values.push(cols[col]); }
             let mut prev = row;
             for row in iter {
-                let pos = prev.iter().zip(row.iter()).position(|(p,r)| p != r).unwrap_or(KW/4);
+                let cols = row.as_chunks::<4>().0;
+                let pos = prev.as_chunks::<4>().0.iter().zip(cols.iter()).position(|(p,r)| p != r).unwrap_or(KW/4);
                 for col in (pos .. KW/4).skip(1) { let len = columns[col].values.len() as u64; columns[col].bounds.push(len); }
-                for col in pos .. KW/4 { columns[col].values.push(row[col]); }
+                for col in pos .. KW/4 { columns[col].values.push(cols[col]); }
                 prev = row;
             }
 


### PR DESCRIPTION
This PR introduces a page-oriented radix sort that avoids some memory antipatterns, specifically requiring the input be in one contiguous allocation, and requiring a second similarly sized allocation to copy to and from. Instead, we maintain a sequence of smaller allocations, "pages", that are drained in order and whose elements are distributed among 256 pages, each of which when they become full go in their own list and are replaced by another modest sized empty page. The process repeats, draining and reusing pages, never spiking much beyond the input page count (potentially up to 512 extra pages, in the worst case afaict). As a bonus, the output are also pages, and you can drain them in order to produce your output, allowing you to deallocate as you go, avoiding again keeping two copies of the data in memory at the same time.

For the moment, the new sort is only used for data loading. It should be helpful for general sorting as well, which also creaks under the weight of the amount of live data needed to accomplish sorting. We'll develop this for a bit, and try and migrate once we understand it better!