### PR TITLE
Restructure `State::implement`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ getopts = { version = "0.2.24" }
 regex = "1.11.1"
 mimalloc = { version = "0.1.48", features = ["v3"] }
 simd-csv = "0.10.3"
-timely_bytes = { version = "0.28", path = "../timely-dataflow/bytes" }
-timely_communication = { version = "0.28", path = "../timely-dataflow/communication" }
+timely_bytes = { version = "0.29", path = "../timely-dataflow/bytes" }
+timely_communication = { version = "0.29", path = "../timely-dataflow/communication" }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -1,14 +1,14 @@
 use std::rc::Rc;
 use std::cell::RefCell;
 
-use timely_communication::{Allocate, allocator::Generic, Bytesable};
+use timely_communication::{allocator::Allocator, Bytesable};
 use crate::facts::{FactLSM, Forest, Lists, Terms};
 use crate::facts::trie::Layer;
 
 #[derive(Default)]
 pub struct Comms {
     /// If set, communication infrastructure.
-    pub ether: Option<Rc<RefCell<Generic>>>,
+    pub ether: Option<Rc<RefCell<Allocator>>>,
     /// An incrementing channel identifier.
     count: usize,
 }
@@ -86,14 +86,14 @@ impl Comms {
     }
 }
 
-impl From<Generic> for Comms {
-    fn from(comm: Generic) -> Self { Self { ether: Some(Rc::new(RefCell::new(comm))), count: 0 } }
+impl From<Allocator> for Comms {
+    fn from(comm: Allocator) -> Self { Self { ether: Some(Rc::new(RefCell::new(comm))), count: 0 } }
 }
 
 use timely_communication::{Push, Pull};
 
 pub struct Channel {
-    comms: Rc<RefCell<Generic>>,
+    comms: Rc<RefCell<Allocator>>,
     sends: Vec<Box<dyn Push<FactMessage>>>,
     recv: Box<dyn Pull<FactMessage>>,
     count: usize,

--- a/src/rules/exec.rs
+++ b/src/rules/exec.rs
@@ -125,8 +125,17 @@ pub fn wco_join<T: Ord + Copy + std::fmt::Debug>(
     potato: T,
     target: &[T],
 ) {
-    // Single atoms are handled using a conventional equijoin.
-    if atoms.len() == 1 { atoms[0].join(comms, salad, terms, target); }
+    if atoms.is_empty() {
+        // No constraints to apply; only the trailing `prune_to` runs.
+    }
+    else if atoms.len() == 1 {
+        // Single atom: conventional equijoin or semijoin, dispatched by `terms`.
+        atoms[0].join(comms, salad, terms, target);
+    }
+    else if terms.is_empty() {
+        // Multi-atom with no new terms is a multi-way semijoin; chain per-atom.
+        for atom in atoms { atom.join(comms, salad, terms, target); }
+    }
     else {
         // Multiple atoms will use worst-case optimal machinery, but we first sequester any columns not referenced by the atoms.
         let shared = salad.terms.iter().filter(|t| atoms.iter().any(|a| a.terms().contains(t))).copied().collect::<Vec<_>>();

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -81,7 +81,17 @@ impl crate::types::State {
             let plan = &plans[&plan_atom];
             let plan_loads = &loads[&plan_atom];
 
-            // Stage 0: Load the recently added facts.
+            // Ensure arranged facts exist before anything else captures conduits — once we
+            // start capturing them it is too late to change others. The pre-pass covers the
+            // driver too (it is present in `plan_loads`), so Stage 0 below need not re-ensure.
+            for (load_atom, (action, _)) in plan_loads.iter() {
+                if logic::resolve(&body[*load_atom]).is_none() {
+                    self.facts.ensure_action(&mut self.comms, body[*load_atom].name.as_str(), action);
+                }
+            }
+
+            // Stage 0: Load the initial added facts.
+            // If `stable` these are all facts, and if not they are only recent novel facts.
             let (action, terms) = &plan_loads[&plan_atom];
             let mut salad = crate::rules::exec::Salad::new(FactLSM::default(), Vec::default());
             if let Some(logic) = logic::resolve(&body[plan_atom]) {
@@ -90,34 +100,24 @@ impl crate::types::State {
                 boxed_atom.join(&mut self.comms, &mut salad, &terms.iter().copied().collect(), &terms);
             }
             else {
-                self.facts.ensure_action(&mut self.comms, body[plan_atom].name.as_str(), action);
                 let dataz = &self.facts.get_action(atom.name.as_str(), action).unwrap();
                 salad.terms = terms.clone();
                 salad.extend(dataz.stable.contents().filter(|_| stable).chain(dataz.recent.as_ref()).cloned());
             }
 
-            // Ensure arranged facts exist first, as once we start capturing them it is too late to change others.
-            for (load_atom, (action, _)) in plan_loads.iter() {
-                if logic::resolve(&body[*load_atom]).is_none() {
-                    self.facts.ensure_action(&mut self.comms, body[*load_atom].name.as_str(), action);
-                }
-            }
-
-            // Stage 1: Semijoin with other atoms that are subsumed by the initial terms.
-            let (init_atoms, _init_terms, init_order) = &plan[0];
-            for load_atom in init_atoms.iter().filter(|a| a != &&plan_atom) {
-                let boxed_atom = build_load_atom(body, plan_atom, *load_atom, plan_loads, &self.facts);
-                boxed_atom.join(&mut self.comms, &mut salad, &Default::default(), init_order);
-            }
-            // We may need to produce the result in a different order.
-            salad.prune_to(&mut self.comms, init_order.iter().copied());
-
-            // Stage 2: Each other plan stage.
-            for (atoms, terms, order) in plan.iter().skip(1) {
-                let others = atoms.iter()
+            // Pre-build all boxed atoms for every plan stage in one pass.
+            // After this operation we no longer read `self.facts` until we need to commit derived facts.
+            let stages_boxed = plan.iter()
+                .map(|(atoms, _, _)| atoms.iter()
+                    .filter(|a| a != &&plan_atom)
                     .map(|load_atom| build_load_atom(body, plan_atom, *load_atom, plan_loads, &self.facts))
-                    .collect::<Vec<_>>();
+                    .collect::<Vec<_>>())
+                .collect::<Vec<_>>();
 
+            // Each stage goes through `wco_join`, although the first stage modifies its terms,
+            // as they are already present in `salad` and re-adding them would confuse `wco_join`.
+            for (i, ((_, plan_terms, order), others)) in plan.iter().zip(stages_boxed).enumerate() {
+                let terms = if i == 0 { &Default::default() } else { plan_terms };
                 exec::wco_join(&mut self.comms, &mut salad, terms, &others[..], &potato, &order[..]);
             }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -63,22 +63,25 @@ impl crate::types::State {
         let head = &rule.head[..];
         let body = &rule.body[..];
 
-        let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body).expect("Unable to plan");
+        // Body atoms that should take a turn as the source of novelty this round.
+        // In `stable` mode only the first body atom drives; in incremental mode every
+        // atom takes a turn, optionally restricted to those whose relation has recent
+        // facts on some worker.
+        let delta_atoms: Vec<usize> = if stable {
+            vec![0]
+        } else if let Some(active) = active_relations {
+            (0..body.len()).filter(|i| active.contains(body[*i].name.as_str())).collect()
+        } else {
+            (0..body.len()).collect()
+        };
 
-        let plan_atoms = if stable { 1 } else { body.len() };
+        let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body, &delta_atoms).expect("Unable to plan");
 
         let potato = ".potato".to_string();
 
-        for (plan_atom, atom) in body[..plan_atoms].iter().enumerate() {
-
-            if !plans.contains_key(&plan_atom) { continue; }
-
-            // Skip this plan when the starting atom has no recent facts on any worker.
-            if let Some(active) = active_relations {
-                if !stable && !active.contains(atom.name.as_str()) { continue; }
-            }
-
-            let plan = &plans[&plan_atom];
+        for (plan_atom, plan) in plans.iter() {
+            let plan_atom = *plan_atom;
+            let atom = &body[plan_atom];
             let plan_loads = &loads[&plan_atom];
 
             // Ensure arranged facts exist before anything else captures conduits — once we
@@ -109,15 +112,13 @@ impl crate::types::State {
             // After this operation we no longer read `self.facts` until we need to commit derived facts.
             let stages_boxed = plan.iter()
                 .map(|(atoms, _, _)| atoms.iter()
-                    .filter(|a| a != &&plan_atom)
                     .map(|load_atom| build_load_atom(body, plan_atom, *load_atom, plan_loads, &self.facts))
                     .collect::<Vec<_>>())
                 .collect::<Vec<_>>();
 
-            // Each stage goes through `wco_join`, although the first stage modifies its terms,
-            // as they are already present in `salad` and re-adding them would confuse `wco_join`.
-            for (i, ((_, plan_terms, order), others)) in plan.iter().zip(stages_boxed).enumerate() {
-                let terms = if i == 0 { &Default::default() } else { plan_terms };
+            // Each stage goes through `wco_join` uniformly. Stage 0's terms have been cleared
+            // by `plan_rule` (driver-loaded terms aren't introduced by stage 0's atom-side ops).
+            for ((_, terms, order), others) in plan.iter().zip(stages_boxed) {
                 exec::wco_join(&mut self.comms, &mut salad, terms, &others[..], &potato, &order[..]);
             }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -79,21 +79,39 @@ impl crate::types::State {
 
         let potato = ".potato".to_string();
 
-        for (plan_atom, plan) in plans.iter() {
-            let plan_atom = *plan_atom;
-            let atom = &body[plan_atom];
-            let plan_loads = &loads[&plan_atom];
-
-            // Ensure arranged facts exist before anything else captures conduits — once we
-            // start capturing them it is too late to change others. The pre-pass covers the
-            // driver too (it is present in `plan_loads`), so Stage 0 below need not re-ensure.
+        //  Build phase.
+        //      1. Ensure arranged facts exist for every load atom across every plan_atom.
+        //      2. Pre-build all boxed atoms for every (plan_atom, stage).
+        for (plan_atom, _plan) in plans.iter() {
+            let plan_loads = &loads[plan_atom];
             for (load_atom, (action, _)) in plan_loads.iter() {
                 if logic::resolve(&body[*load_atom]).is_none() {
                     self.facts.ensure_action(&mut self.comms, body[*load_atom].name.as_str(), action);
                 }
             }
+        }
+        let all_stages_boxed: Vec<_> = plans.iter()
+            .map(|(plan_atom, plan)| {
+                let plan_loads = &loads[plan_atom];
+                plan.iter()
+                    .map(|(atoms, _, _)| atoms.iter()
+                        .map(|load_atom| build_load_atom(body, *plan_atom, *load_atom, plan_loads, &self.facts))
+                        .collect::<Vec<_>>())
+                    .collect::<Vec<_>>()
+            })
+            .collect();
 
-            // Stage 0: Load the initial added facts.
+        //  Execute phase. Each planned delta atom
+        //      1. loads its facts, then
+        //      2. repeatedly joins in new terms, then
+        //      3. commits derived facts to the stores for head atoms.
+
+        for ((plan_atom, plan), stages_boxed) in plans.iter().zip(all_stages_boxed) {
+            let plan_atom = *plan_atom;
+            let atom = &body[plan_atom];
+            let plan_loads = &loads[&plan_atom];
+
+            // Step 1: Load the initial facts to seed the sequence of joins.
             // If `stable` these are all facts, and if not they are only recent novel facts.
             let (action, terms) = &plan_loads[&plan_atom];
             let mut salad = crate::rules::exec::Salad::new(FactLSM::default(), Vec::default());
@@ -108,21 +126,12 @@ impl crate::types::State {
                 salad.extend(dataz.stable.contents().filter(|_| stable).chain(dataz.recent.as_ref()).cloned());
             }
 
-            // Pre-build all boxed atoms for every plan stage in one pass.
-            // After this operation we no longer read `self.facts` until we need to commit derived facts.
-            let stages_boxed = plan.iter()
-                .map(|(atoms, _, _)| atoms.iter()
-                    .map(|load_atom| build_load_atom(body, plan_atom, *load_atom, plan_loads, &self.facts))
-                    .collect::<Vec<_>>())
-                .collect::<Vec<_>>();
-
-            // Each stage goes through `wco_join` uniformly. Stage 0's terms have been cleared
-            // by `plan_rule` (driver-loaded terms aren't introduced by stage 0's atom-side ops).
+            // Step 2: Repeatedly join in sets of terms through sets of atoms.
             for ((_, terms, order), others) in plan.iter().zip(stages_boxed) {
                 exec::wco_join(&mut self.comms, &mut salad, terms, &others[..], &potato, &order[..]);
             }
 
-            // Stage 3: Commit produced facts back to `self.facts`, one head atom at a time.
+            // Stage 3: Commit produced facts back to head atoms in `self.facts`.
             self.emit_head_facts(head, salad);
         }
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -15,7 +15,7 @@
 //! These traits are implemented for relations that are *explicit* (represented by data) and *implicit* (represented by code), and in-between (e.g. antijoins).
 
 use crate::types::{Atom, Rule, Action, Term};
-use crate::facts::{FactContainer, FactLSM, Relations};
+use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
 
 pub mod plan;
 pub mod exec;
@@ -29,25 +29,25 @@ pub use exec::ExecAtom;
 /// properties, and threads the appropriate stable/recent split per the
 /// semi-naive convention: atoms whose index exceeds the driver's contribute
 /// their `recent` facts, others contribute only `stable`.
-fn build_load_atom<'a: 'b, 'b>(
+fn build_load_atom<'a>(
     body: &'a [Atom],
     plan_atom: usize,
     load_atom: usize,
-    loads: &'b std::collections::BTreeMap<usize, plan::Load<&'a String>>,
-    facts: &'b Relations,
-) -> Box<dyn exec::ExecAtom<&'a String> + 'b>
-{
+    loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
+    facts: &Relations,
+) -> Box<dyn exec::ExecAtom<&'a String> + 'a> {
     if let Some(logic) = logic::resolve(&body[load_atom]) {
         Box::new(logic)
     } else {
         let (load_action, load_terms) = &loads[&load_atom];
         let other = facts.get_action(body[load_atom].name.as_str(), load_action).unwrap();
         let to_chain = if load_atom > plan_atom { other.recent.as_ref() } else { None };
-        let other_facts = other.stable.contents().chain(to_chain).collect::<Vec<_>>();
+        let other_facts: Vec<Forest<Terms>> = other.stable.contents().chain(to_chain).cloned().collect();
+        let owned_terms: Vec<&'a String> = load_terms.clone();
         if body[load_atom].anti {
-            Box::new(antijoin::Anti((other_facts, load_terms)))
+            Box::new(antijoin::Anti((other_facts, owned_terms)))
         } else {
-            Box::new((other_facts, load_terms))
+            Box::new((other_facts, owned_terms))
         }
     }
 }
@@ -177,9 +177,9 @@ pub mod data {
         fn ground(&self, terms: &BTreeSet<T>) -> BTreeSet<T> { self.difference(terms).cloned().collect() }
     }
 
-    impl<'a, T: Ord + Copy + std::fmt::Debug> ExecAtom<T> for (Vec<&'a Forest<Terms>>, &'a Vec<T>) {
+    impl<T: Ord + Copy + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<T>) {
 
-        fn terms(&self) -> &[T] { self.1 }
+        fn terms(&self) -> &[T] { &self.1 }
 
         fn count(&self, comms: &mut Comms, salad: &mut Salad<T>, terms: &BTreeSet<T>, other_index: u8) {
 
@@ -271,7 +271,7 @@ pub mod data {
                     let join_terms = salad.terms.iter().chain(salad.terms[..prefix].iter()).chain(terms.iter()).copied().collect::<Vec<_>>();
                     // Our output join order (until we learn how to do FDB shapes) is the first of `others` not equal to ourself.
                     let projection = after.iter().map(|t| join_terms.iter().position(|t2| t == t2).unwrap()).collect::<Vec<_>>();
-                    salad.facts.extend(delta.join_many(my_facts.iter().copied(), prefix, &projection[..], conduit));
+                    salad.facts.extend(delta.join_many(my_facts.iter(), prefix, &projection[..], conduit));
                 }
                 else {
                     salad.facts.extend(conduit.finish());
@@ -307,9 +307,9 @@ pub mod antijoin {
         fn ground(&self, _terms: &BTreeSet<T>) -> BTreeSet<T> { Default::default() }
     }
 
-    impl<'a, T: Ord + Copy+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<&'a Forest<Terms>>, &'a Vec<T>)> {
+    impl<T: Ord + Copy+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<Forest<Terms>>, Vec<T>)> {
 
-        fn terms(&self) -> &[T] { self.0.1 }
+        fn terms(&self) -> &[T] { &self.0.1 }
 
         fn count(&self, _: &mut Comms, _: &mut Salad<T>, _: &BTreeSet<T>, _: u8) { }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -14,14 +14,43 @@
 //!
 //! These traits are implemented for relations that are *explicit* (represented by data) and *implicit* (represented by code), and in-between (e.g. antijoins).
 
-use crate::types::{Rule, Action, Term};
-use crate::facts::{FactContainer, FactLSM};
+use crate::types::{Atom, Rule, Action, Term};
+use crate::facts::{FactContainer, FactLSM, Relations};
 
 pub mod plan;
 pub mod exec;
 
 pub use plan::PlanAtom;
 pub use exec::ExecAtom;
+
+/// Constructs a boxed `ExecAtom` for a non-driver atom in a rule body.
+///
+/// Selects between logic, antijoin, and data variants based on the atom's
+/// properties, and threads the appropriate stable/recent split per the
+/// semi-naive convention: atoms whose index exceeds the driver's contribute
+/// their `recent` facts, others contribute only `stable`.
+fn build_load_atom<'a: 'b, 'b>(
+    body: &'a [Atom],
+    plan_atom: usize,
+    load_atom: usize,
+    loads: &'b std::collections::BTreeMap<usize, plan::Load<&'a String>>,
+    facts: &'b Relations,
+) -> Box<dyn exec::ExecAtom<&'a String> + 'b>
+{
+    if let Some(logic) = logic::resolve(&body[load_atom]) {
+        Box::new(logic)
+    } else {
+        let (load_action, load_terms) = &loads[&load_atom];
+        let other = facts.get_action(body[load_atom].name.as_str(), load_action).unwrap();
+        let to_chain = if load_atom > plan_atom { other.recent.as_ref() } else { None };
+        let other_facts = other.stable.contents().chain(to_chain).collect::<Vec<_>>();
+        if body[load_atom].anti {
+            Box::new(antijoin::Anti((other_facts, load_terms)))
+        } else {
+            Box::new((other_facts, load_terms))
+        }
+    }
+}
 
 impl crate::types::State {
 
@@ -50,9 +79,10 @@ impl crate::types::State {
             }
 
             let plan = &plans[&plan_atom];
+            let plan_loads = &loads[&plan_atom];
 
             // Stage 0: Load the recently added facts.
-            let (action, terms) = &loads[&plan_atom][&plan_atom];
+            let (action, terms) = &plan_loads[&plan_atom];
             let mut salad = crate::rules::exec::Salad::new(FactLSM::default(), Vec::default());
             if let Some(logic) = logic::resolve(&body[plan_atom]) {
                 let boxed_atom: Box::<dyn exec::ExecAtom<&String>+'_> = Box::new(logic);
@@ -67,7 +97,7 @@ impl crate::types::State {
             }
 
             // Ensure arranged facts exist first, as once we start capturing them it is too late to change others.
-            for (load_atom, (action, _)) in loads[&plan_atom].iter() {
+            for (load_atom, (action, _)) in plan_loads.iter() {
                 if logic::resolve(&body[*load_atom]).is_none() {
                     self.facts.ensure_action(&mut self.comms, body[*load_atom].name.as_str(), action);
                 }
@@ -76,17 +106,7 @@ impl crate::types::State {
             // Stage 1: Semijoin with other atoms that are subsumed by the initial terms.
             let (init_atoms, _init_terms, init_order) = &plan[0];
             for load_atom in init_atoms.iter().filter(|a| a != &&plan_atom) {
-                let boxed_atom: Box::<dyn exec::ExecAtom<&String>+'_> = {
-                    if let Some(logic) = logic::resolve(&body[*load_atom]) { Box::new(logic) }
-                    else {
-                        let (load_action, load_terms) = &loads[&plan_atom][load_atom];
-                        let other = &self.facts.get_action(body[*load_atom].name.as_str(), load_action).unwrap();
-                        let to_chain = if load_atom > &plan_atom { other.recent.as_ref() } else { None };
-                        let other_facts = other.stable.contents().chain(to_chain).collect::<Vec<_>>();
-                        if body[*load_atom].anti { Box::new(antijoin::Anti((other_facts, load_terms))) }
-                        else { Box::new((other_facts, load_terms)) }
-                    }
-                };
+                let boxed_atom = build_load_atom(body, plan_atom, *load_atom, plan_loads, &self.facts);
                 boxed_atom.join(&mut self.comms, &mut salad, &Default::default(), init_order);
             }
             // We may need to produce the result in a different order.
@@ -94,51 +114,49 @@ impl crate::types::State {
 
             // Stage 2: Each other plan stage.
             for (atoms, terms, order) in plan.iter().skip(1) {
-                let others = atoms.iter().map(|load_atom| {
-                    let boxed_atom: Box::<dyn exec::ExecAtom<&String>+'_> = {
-                        if let Some(logic) = logic::resolve(&body[*load_atom]) { Box::new(logic) }
-                        else {
-                            let (load_action, load_terms) = &loads[&plan_atom][load_atom];
-                            let other = &self.facts.get_action(body[*load_atom].name.as_str(), load_action).unwrap();
-                            let to_chain = if load_atom > &plan_atom { other.recent.as_ref() } else { None };
-                            let other_facts = other.stable.contents().chain(to_chain).collect::<Vec<_>>();
-                            if body[*load_atom].anti { Box::new(antijoin::Anti((other_facts, load_terms))) }
-                            else { Box::new((other_facts, load_terms)) }
-                        }
-                    };
-                    boxed_atom
-                }).collect::<Vec<_>>();
+                let others = atoms.iter()
+                    .map(|load_atom| build_load_atom(body, plan_atom, *load_atom, plan_loads, &self.facts))
+                    .collect::<Vec<_>>();
 
                 exec::wco_join(&mut self.comms, &mut salad, terms, &others[..], &potato, &order[..]);
             }
 
-            // Stage 3: We now need to form up the facts to commit back to `facts`.
-            // It is possible that with a single head we have the terms in the right order,
-            // and can simply commit `delta`. There could be multiple heads, and the action
-            // could be not the identity.
-            let exact_match = head.iter().position(|a| {
-                a.terms.len() == salad.arity() &&
-                a.terms.iter().zip(salad.terms.iter()).all(|(h,d)| h.as_var() == Some(d))
-            });
+            // Stage 3: Commit produced facts back to `self.facts`, one head atom at a time.
+            self.emit_head_facts(head, salad);
+        }
+    }
 
-            let thresh = 200_000_000 / self.comms.peers();
-            for (_, atom) in head.iter().enumerate().filter(|(pos,_)| Some(*pos) != exact_match) {
-                let mut action = Action::with_arity(salad.arity());
-                action.projection = atom.terms.iter().map(|t| match t {
-                    Term::Var(name) => Ok(salad.terms.iter().position(|t2| t2 == &name).expect(format!("Failed to find {:?} in {:?}", name, salad.terms).as_str())),
-                    Term::Lit(data) => Err(data.clone()),
-                }).collect();
-                if let Some(delta) = salad.facts.flatten() {
-                    self.extend_facts(atom, delta.act_on(&action, thresh));
-                    salad.extend([delta]);
-                }
-                else {
-                    self.extend_facts(atom, Default::default());
-                }
+    /// Projects `salad` through each head atom and extends the corresponding relation.
+    ///
+    /// If a head atom's term order matches `salad` exactly, its facts are committed
+    /// without re-projection; otherwise, an `Action` is built for the head and applied.
+    fn emit_head_facts(&mut self, head: &[Atom], mut salad: crate::rules::exec::Salad<&String>) {
+
+        // It is possible that with a single head we have the terms in the right order,
+        // and can simply commit `delta`. There could be multiple heads, and the action
+        // could be not the identity.
+        let exact_match = head.iter().position(|a| {
+            a.terms.len() == salad.arity() &&
+            a.terms.iter().zip(salad.terms.iter()).all(|(h,d)| h.as_var() == Some(d))
+        });
+
+        let thresh = 200_000_000 / self.comms.peers();
+        for (_, atom) in head.iter().enumerate().filter(|(pos,_)| Some(*pos) != exact_match) {
+            let mut action = Action::with_arity(salad.arity());
+            action.projection = atom.terms.iter().map(|t| match t {
+                Term::Var(name) => Ok(salad.terms.iter().position(|t2| t2 == &name).expect(format!("Failed to find {:?} in {:?}", name, salad.terms).as_str())),
+                Term::Lit(data) => Err(data.clone()),
+            }).collect();
+            if let Some(delta) = salad.facts.flatten() {
+                self.extend_facts(atom, delta.act_on(&action, thresh));
+                salad.extend([delta]);
             }
-            if let Some(pos) = exact_match {
-                self.extend_facts(&head[pos], salad.facts);
+            else {
+                self.extend_facts(atom, Default::default());
             }
+        }
+        if let Some(pos) = exact_match {
+            self.extend_facts(&head[pos], salad.facts);
         }
     }
 }

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -39,7 +39,13 @@ pub type Plans<A, T> = BTreeMap<A, Plan<A, T>>;
 pub type Load<T> = (Action<Vec<u8>>, Vec<T>);
 pub type Loads<A, T> = BTreeMap<A, BTreeMap<A, Load<T>>>;
 
-pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(head: &'a [Atom], body: &'a [Atom]) -> Result<(Plans<usize, &'a String>, Loads<usize, &'a String>), String> {
+/// Plan the rule, generating a per-`delta_atoms` update plan.
+///
+/// Each entry in `delta_atoms` names a body atom that should take a turn as the source of
+/// novelty (the semi-naive delta). The returned plans map contains an entry for each
+/// requested delta atom that the strategy can plan (logic atoms that can't ground all
+/// their terms are silently dropped, regardless of the request).
+pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(head: &'a [Atom], body: &'a [Atom], delta_atoms: &[usize]) -> Result<(Plans<usize, &'a String>, Loads<usize, &'a String>), String> {
 
     // We'll pick a target term order for the first head; other heads may require transforms.
     // If we have multiple heads and one has no literals or repetitions, that would be best.
@@ -57,7 +63,7 @@ pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(head: &'a [Atom], body: &'a
 
     // We'll want to pre-plan the term orders for each atom update rule, so that we can
     // pre-ensure that the necessary input shapes exist, with each atom in term order.
-    let plans = S::plan_rule(&atoms, &head_terms);
+    let mut plans = S::plan_rule(&atoms, delta_atoms, &head_terms);
 
     // Actions for each atom that would produce the output in `terms` order.
     // Their output columns should now be ordered as `atoms_to_terms[atom]`.
@@ -110,6 +116,18 @@ pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(head: &'a [Atom], body: &'a
                  .collect();
 
             load_actions.get_mut(&plan_atom).map(|l| l.insert(plan_atom, (action, order)));
+        }
+    }
+
+    // Tidy stage 0 for the executor: drop the driver from its own stage 0 atoms (it is
+    // already loaded as the salad), and clear stage 0's terms (they are present in the
+    // salad from the driver load, not introduced by stage 0's atom-side operations).
+    // Both transformations are post-hoc — the planner's projection logic above relies
+    // on stage 0's terms holding `init_terms`, so we wait until that work is done.
+    for (plan_atom, plan) in plans.iter_mut() {
+        if let Some((atoms, terms, _)) = plan.first_mut() {
+            atoms.remove(plan_atom);
+            terms.clear();
         }
     }
 
@@ -176,8 +194,12 @@ pub trait Strategy<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug> {
     /// atom can ground any of their terms as a function of other ground terms.
     fn plan_atom(atom: A, atoms_to_terms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, terms_to_atoms: &BTreeMap<T, BTreeSet<A>>) -> Plan<A, T>;
 
-    /// Plans updates for each atom in the rule.
-    fn plan_rule(boxed_atoms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, head_terms: &[T]) -> BTreeMap<A, Plan<A, T>> {
+    /// Plans updates for the requested `delta_atoms`.
+    ///
+    /// Each `delta_atom` is a body atom that should take a turn as the source of novelty.
+    /// Atoms that the strategy can't ground (e.g. logic atoms) are silently dropped from
+    /// the result.
+    fn plan_rule(boxed_atoms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, delta_atoms: &[A], head_terms: &[T]) -> BTreeMap<A, Plan<A, T>> {
 
         let mut terms_to_atoms: BTreeMap<T, BTreeSet<A>> = Default::default();
         for (atom, boxed) in boxed_atoms.iter() { for term in boxed.terms() { terms_to_atoms.entry(term).or_default().insert(*atom); } }
@@ -194,8 +216,8 @@ pub trait Strategy<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug> {
         }
 
         let mut rule_plan = BTreeMap::default();
-        for atom in boxed_atoms.keys().copied() {
-            if boxed_atoms[&atom].terms() == boxed_atoms[&atom].ground(&Default::default()) {
+        for atom in delta_atoms.iter().copied() {
+            if boxed_atoms.get(&atom).is_some_and(|b| b.terms() == b.ground(&Default::default())) {
                 let mut atom_plan = Self::plan_atom(atom, boxed_atoms, &terms_to_atoms);
 
                 // Fuse plan stages with identical single atoms.


### PR DESCRIPTION
The logic that implements a rule tangled up several concerns, from planning to fetching data to execution. They were all some amount interleaved. I'm working to de-interleave them, and this PR does a fair bit of this. The planning now starts by taking information about which delta paths we want to plan and plans only those, then builds the data assets before starting, and then goes through each of the plans executing.