### PR TITLE
Introduce support for "views": non materialized rule heads

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,11 +73,33 @@ pub mod types {
         pub fn as_var(&self) -> Option<&String> { if let Term::Var(name) = self { Some(name) } else { None }}
     }
 
+    /// Per-relation declaration metadata.
+    ///
+    /// Populated either explicitly via `.decl` or implicitly when a relation is first
+    /// referenced by a rule. Once an arity is recorded for a name, subsequent rules
+    /// (and any later `.decl`) must agree on it.
+    #[derive(Clone, Debug, Default)]
+    pub struct RelationDecl {
+        /// Number of columns.
+        pub arity: usize,
+        /// Whether this name was declared via `.decl` (vs. inferred from a rule reference).
+        pub explicit: bool,
+        /// Whether the relation is virtual (computed on demand, not materialized).
+        ///
+        /// Only meaningful when `explicit` is true; implicit declarations are never virtual.
+        pub virt: bool,
+    }
+
     #[derive(Default)]
     pub struct State {
         pub rules: Vec<(Rule, Vec<std::time::Duration>)>,
         pub facts: facts::Relations,
         pub comms: super::comms::Comms,
+        /// Per-relation declaration metadata, keyed by name.
+        ///
+        /// Entries are inserted either by `.decl` (explicit) or by first use in a rule
+        /// (implicit). Arity is checked for consistency on every subsequent reference.
+        pub decls: std::collections::BTreeMap<String, RelationDecl>,
     }
 
     impl State {
@@ -121,6 +143,55 @@ pub mod types {
         }
 
         pub fn push(&mut self, rule: Rule) {
+            // Walk every atom and accumulate any errors before mutating `decls`. This
+            // way a rule with multiple problems reports all of them at once, and a
+            // rejected rule never leaves a half-committed implicit declaration behind.
+            let mut errors: Vec<String> = Vec::new();
+            let mut to_insert: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+            let mut reported: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+            for atom in rule.head.iter().chain(rule.body.iter()) {
+                let name = atom.name.as_str();
+                let arity = atom.terms.len();
+                match self.decls.get(name) {
+                    Some(decl) => {
+                        if decl.arity != arity && !reported.contains(name) {
+                            errors.push(format!(
+                                "rule references `{}` with arity {}, but it was previously declared with arity {}.",
+                                name, arity, decl.arity
+                            ));
+                            reported.insert(name.to_string());
+                        }
+                        else if decl.virt && !reported.contains(name) {
+                            errors.push(format!(
+                                "rule references virtual relation `{}`, but sum-atom support is not yet implemented.",
+                                name
+                            ));
+                            reported.insert(name.to_string());
+                        }
+                    }
+                    None => {
+                        match to_insert.get(name) {
+                            Some(&prev_arity) if prev_arity != arity && !reported.contains(name) => {
+                                errors.push(format!(
+                                    "rule uses `{}` with both arity {} and arity {}.",
+                                    name, prev_arity, arity
+                                ));
+                                reported.insert(name.to_string());
+                            }
+                            Some(_) => { /* same arity, already pending */ }
+                            None => { to_insert.insert(name.to_string(), arity); }
+                        }
+                    }
+                }
+            }
+            if !errors.is_empty() {
+                for err in errors { println!("{}", err); }
+                println!("rule discarded.");
+                return;
+            }
+            for (name, arity) in to_insert {
+                self.decls.insert(name, RelationDecl { arity, explicit: false, virt: false });
+            }
             if rule.body.is_empty() {
                 for atom in rule.head.iter() {
                     use columnar::Push;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,12 @@ pub mod types {
                     .filter_map(|&i| names.get(i).map(|s| s.as_str()))
                     .collect();
                 for index in 0 .. self.rules.len() {
+                    // Skip rules whose head names a virtual relation; these are
+                    // defining rules, evaluated on demand via SumAtom rather than fired.
+                    let head_is_virtual = self.rules[index].0.head.iter().any(|atom|
+                        self.decls.get(&atom.name).map_or(false, |d| d.virt)
+                    );
+                    if head_is_virtual { continue; }
                     let timer = std::time::Instant::now();
                     self.implement(&self.rules[index].0.clone(), false, Some(&active_names));
                     self.rules[index].1.push(timer.elapsed());
@@ -161,13 +167,9 @@ pub mod types {
                             ));
                             reported.insert(name.to_string());
                         }
-                        else if decl.virt && !reported.contains(name) {
-                            errors.push(format!(
-                                "rule references virtual relation `{}`, but sum-atom support is not yet implemented.",
-                                name
-                            ));
-                            reported.insert(name.to_string());
-                        }
+                        // Note: virtual references are now allowed in both head (defining
+                        // rule, stored but not auto-fired) and body (resolved via SumAtom
+                        // during planning).
                     }
                     None => {
                         match to_insert.get(name) {
@@ -213,9 +215,19 @@ pub mod types {
                 }
             }
             else {
-                let timer = std::time::Instant::now();
-                self.implement(&rule, true, None);
-                self.rules.push((rule, vec![timer.elapsed()]));
+                // If any head atom names a virtual relation, this is a defining rule:
+                // store it (so it can be looked up during sum-atom construction) but skip
+                // the immediate `implement` call (we don't materialize virtual relations).
+                let head_is_virtual = rule.head.iter().any(|atom|
+                    self.decls.get(&atom.name).map_or(false, |d| d.virt)
+                );
+                if head_is_virtual {
+                    self.rules.push((rule, vec![std::time::Duration::ZERO]));
+                } else {
+                    let timer = std::time::Instant::now();
+                    self.implement(&rule, true, None);
+                    self.rules.push((rule, vec![timer.elapsed()]));
+                }
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,10 +84,10 @@ pub mod types {
         pub arity: usize,
         /// Whether this name was declared via `.decl` (vs. inferred from a rule reference).
         pub explicit: bool,
-        /// Whether the relation is virtual (computed on demand, not materialized).
+        /// Whether the relation is a view (computed on demand, not materialized).
         ///
-        /// Only meaningful when `explicit` is true; implicit declarations are never virtual.
-        pub virt: bool,
+        /// Only meaningful when `explicit` is true; implicit declarations are never views.
+        pub view: bool,
     }
 
     #[derive(Default)]
@@ -112,12 +112,12 @@ pub mod types {
                     .filter_map(|&i| names.get(i).map(|s| s.as_str()))
                     .collect();
                 for index in 0 .. self.rules.len() {
-                    // Skip rules whose head names a virtual relation; these are
-                    // defining rules, evaluated on demand via SumAtom rather than fired.
-                    let head_is_virtual = self.rules[index].0.head.iter().any(|atom|
-                        self.decls.get(&atom.name).map_or(false, |d| d.virt)
+                    // Skip rules whose head names a view; these are defining rules,
+                    // evaluated on demand via the View atom rather than fired.
+                    let head_is_view = self.rules[index].0.head.iter().any(|atom|
+                        self.decls.get(&atom.name).map_or(false, |d| d.view)
                     );
-                    if head_is_virtual { continue; }
+                    if head_is_view { continue; }
                     let timer = std::time::Instant::now();
                     self.implement(&self.rules[index].0.clone(), false, Some(&active_names));
                     self.rules[index].1.push(timer.elapsed());
@@ -167,9 +167,9 @@ pub mod types {
                             ));
                             reported.insert(name.to_string());
                         }
-                        // Note: virtual references are now allowed in both head (defining
-                        // rule, stored but not auto-fired) and body (resolved via SumAtom
-                        // during planning).
+                        // Note: view references are now allowed in both head (defining
+                        // rule, stored but not auto-fired) and body (resolved via the View
+                        // atom during planning).
                     }
                     None => {
                         match to_insert.get(name) {
@@ -192,7 +192,7 @@ pub mod types {
                 return;
             }
             for (name, arity) in to_insert {
-                self.decls.insert(name, RelationDecl { arity, explicit: false, virt: false });
+                self.decls.insert(name, RelationDecl { arity, explicit: false, view: false });
             }
             if rule.body.is_empty() {
                 for atom in rule.head.iter() {
@@ -215,13 +215,13 @@ pub mod types {
                 }
             }
             else {
-                // If any head atom names a virtual relation, this is a defining rule:
-                // store it (so it can be looked up during sum-atom construction) but skip
-                // the immediate `implement` call (we don't materialize virtual relations).
-                let head_is_virtual = rule.head.iter().any(|atom|
-                    self.decls.get(&atom.name).map_or(false, |d| d.virt)
+                // If any head atom names a view, this is a defining rule:
+                // store it (so it can be looked up during view-atom construction) but skip
+                // the immediate `implement` call (we don't materialize views).
+                let head_is_view = rule.head.iter().any(|atom|
+                    self.decls.get(&atom.name).map_or(false, |d| d.view)
                 );
-                if head_is_virtual {
+                if head_is_view {
                     self.rules.push((rule, vec![std::time::Duration::ZERO]));
                 } else {
                     let timer = std::time::Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,11 +176,70 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                     println!("time:\t{:?}\t{:?}", timer.elapsed(), words.collect::<Vec<_>>());
                     *timer = std::time::Instant::now();
                 }
-                ".wipe" => { state.facts = Default::default(); state.rules = Default::default(); *bytes = Default::default(); }
+                ".decl" => {
+                    // `.decl name(_, _, ...) [flags]` declares a relation's arity and any
+                    // attribute flags (currently just `virtual`). If the name has already
+                    // been seen (explicitly or implicitly) the arity must match, and any
+                    // explicit prior declaration cannot be reissued with conflicting flags.
+                    let rest: String = words.collect::<Vec<_>>().join(" ");
+                    match parse_decl(rest.as_str()) {
+                        Some((name, arity, flags)) => {
+                            let virt = flags.iter().any(|f| f == "virtual");
+                            for flag in flags.iter() {
+                                if flag != "virtual" {
+                                    println!(".decl: unknown flag `{}` (known flags: virtual)", flag);
+                                    return;
+                                }
+                            }
+                            match state.decls.get(&name) {
+                                Some(prior) if prior.arity != arity => {
+                                    println!(
+                                        ".decl: name `{}` already used with arity {}; cannot redeclare with arity {}.",
+                                        name, prior.arity, arity
+                                    );
+                                }
+                                Some(prior) if prior.explicit && (prior.virt != virt) => {
+                                    println!(
+                                        ".decl: name `{}` already declared; cannot reissue with conflicting flags.",
+                                        name
+                                    );
+                                }
+                                _ => {
+                                    state.decls.insert(
+                                        name,
+                                        types::RelationDecl { arity, explicit: true, virt },
+                                    );
+                                }
+                            }
+                        }
+                        None => { println!(".decl requires `.decl name(_, _, ...) [flags]`"); }
+                    }
+                }
+                ".wipe" => { state.facts = Default::default(); state.rules = Default::default(); state.decls = Default::default(); *bytes = Default::default(); }
                 _ => { println!("Parse failure: {:?}", text); }
             }
         }
     }
+}
+
+/// Parses a `.decl` directive's argument: `name(_, _, ...) [flags]` (with optional
+/// trailing `.`), returning `(name, arity, flags)`. Arity is the number of
+/// comma-separated placeholders; flags are space-separated tokens after the closing
+/// paren. An empty argument list `name()` yields arity 0.
+fn parse_decl(text: &str) -> Option<(String, usize, Vec<String>)> {
+    let trimmed = text.trim().trim_end_matches('.').trim();
+    let lparen = trimmed.find('(')?;
+    let rparen = trimmed.rfind(')')?;
+    if rparen < lparen { return None; }
+    let name = trimmed[..lparen].trim().to_string();
+    if name.is_empty() { return None; }
+    let inside = trimmed[lparen + 1..rparen].trim();
+    let arity = if inside.is_empty() { 0 } else { inside.split(',').count() };
+    let flags = trimmed[rparen + 1..]
+        .split_whitespace()
+        .map(|s| s.to_string())
+        .collect();
+    Some((name, arity, flags))
 }
 
 fn exec_file(filename: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec<u8>, usize>, timer: &mut std::time::Instant) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,16 +178,16 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                 }
                 ".decl" => {
                     // `.decl name(_, _, ...) [flags]` declares a relation's arity and any
-                    // attribute flags (currently just `virtual`). If the name has already
+                    // attribute flags (currently just `view`). If the name has already
                     // been seen (explicitly or implicitly) the arity must match, and any
                     // explicit prior declaration cannot be reissued with conflicting flags.
                     let rest: String = words.collect::<Vec<_>>().join(" ");
                     match parse_decl(rest.as_str()) {
                         Some((name, arity, flags)) => {
-                            let virt = flags.iter().any(|f| f == "virtual");
+                            let view = flags.iter().any(|f| f == "view");
                             for flag in flags.iter() {
-                                if flag != "virtual" {
-                                    println!(".decl: unknown flag `{}` (known flags: virtual)", flag);
+                                if flag != "view" {
+                                    println!(".decl: unknown flag `{}` (known flags: view)", flag);
                                     return;
                                 }
                             }
@@ -198,7 +198,7 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                                         name, prior.arity, arity
                                     );
                                 }
-                                Some(prior) if prior.explicit && (prior.virt != virt) => {
+                                Some(prior) if prior.explicit && (prior.view != view) => {
                                     println!(
                                         ".decl: name `{}` already declared; cannot reissue with conflicting flags.",
                                         name
@@ -207,7 +207,7 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                                 _ => {
                                     state.decls.insert(
                                         name,
-                                        types::RelationDecl { arity, explicit: true, virt },
+                                        types::RelationDecl { arity, explicit: true, view },
                                     );
                                 }
                             }

--- a/src/rules/atoms/logic.rs
+++ b/src/rules/atoms/logic.rs
@@ -21,12 +21,19 @@ use crate::comms::Comms;
 ///
 /// The implementation is a type that implements both `PlanAtom` and `ExecAtom`, and can be boxed as either.
 pub fn resolve(atom: &Atom) -> Option<LogicRel<&String>> {
+    resolve_with_subst(atom, &plan::Subst::new())
+}
+
+/// Substitution-aware variant of `resolve`. Used by view planning so that head-var
+/// renames (and lit pushdown) flow into the logic atom's `bound`/`terms`. For the
+/// non-view path, an empty `subst` (via `resolve`) gives the original behavior.
+pub fn resolve_with_subst<'a>(atom: &'a Atom, subst: &plan::Subst<'a>) -> Option<LogicRel<&'a String>> {
     match atom.name.as_str() {
-        ":noteq" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::NotEq } ), atom)),
-        ":range" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Range } ), atom)),
-        ":plus"  => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Plus } ),  atom)),
-        ":times" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Times } ), atom)),
-        ":print" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Print(atom.terms.len()) } ), atom)),
+        ":noteq" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::NotEq } ), atom, subst)),
+        ":range" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Range } ), atom, subst)),
+        ":plus"  => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Plus } ),  atom, subst)),
+        ":times" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Times } ), atom, subst)),
+        ":print" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Print(atom.terms.len()) } ), atom, subst)),
         _ => None,
     }
 }
@@ -89,7 +96,25 @@ pub struct LogicRel<T> {
 impl<'a> LogicRel<&'a String> {
     /// Create a new instance of `Self` from batch logic and the atom itself.
     pub fn new(logic: Box<dyn super::logic::BatchLogic>, atom: &'a Atom) -> Self {
-        let bound = atom.terms.iter().map(|t| match t { Term::Var(name) => Ok(name), Term::Lit(data) => Err(data.clone()) }).collect::<Vec<_>>();
+        Self::new_with_subst(logic, atom, &plan::Subst::new())
+    }
+
+    /// Substitution-aware variant: walks atom terms applying `subst`, so a body var
+    /// renamed via `Term::Var(new_name)` appears under its new name in `bound`/`terms`,
+    /// and a body var pushed down to `Term::Lit(value)` becomes a positional literal.
+    pub fn new_with_subst(
+        logic: Box<dyn super::logic::BatchLogic>,
+        atom: &'a Atom,
+        subst: &plan::Subst<'a>,
+    ) -> Self {
+        let bound: Vec<Result<&'a String, Vec<u8>>> = atom.terms.iter().map(|t| match t {
+            Term::Var(name) => match subst.get(name).copied() {
+                Some(Term::Var(new_name)) => Ok(new_name),
+                Some(Term::Lit(data)) => Err(data.clone()),
+                None => Ok(name),
+            },
+            Term::Lit(data) => Err(data.clone()),
+        }).collect();
         let terms = bound.iter().flatten().collect::<BTreeSet<_>>().into_iter().copied().collect::<Vec<_>>();
         Self { logic, bound, terms }
     }

--- a/src/rules/atoms/mod.rs
+++ b/src/rules/atoms/mod.rs
@@ -3,3 +3,4 @@
 pub mod data;
 pub mod anti;
 pub mod logic;
+pub mod sum;

--- a/src/rules/atoms/mod.rs
+++ b/src/rules/atoms/mod.rs
@@ -3,4 +3,4 @@
 pub mod data;
 pub mod anti;
 pub mod logic;
-pub mod sum;
+pub mod view;

--- a/src/rules/atoms/sum.rs
+++ b/src/rules/atoms/sum.rs
@@ -1,0 +1,153 @@
+//! Sum atom: an `ExecAtom`/`PlanAtom` for virtual relation references.
+//!
+//! When a body atom names a virtual relation (declared via `.decl name(_, _, ...) virtual`),
+//! the planner constructs a `SumPlan` for it (lightweight, no apparatus) and the executor
+//! constructs a `Sum` whose disjuncts are the apparatus pre-built from each defining rule.
+//!
+//! For now: `Sum::seed` evaluates each disjunct, projects through the disjunct's head, and
+//! unions the results. `Sum::count` is a no-op (sum atoms never propose values via the count
+//! protocol). `Sum::join` is not yet implemented — the seeded variant would be needed for
+//! sum atoms in non-driver positions.
+
+use std::collections::BTreeSet;
+use std::sync::OnceLock;
+
+use crate::comms::Comms;
+use crate::facts::{FactContainer, FactLSM, Forest, Terms};
+use crate::rules::exec::{self, Salad};
+use crate::rules::plan::{self, PlanAtom};
+use crate::rules::{ExecAtom, DriverApparatus};
+use crate::types::{Action, Atom, Rule, Term};
+
+/// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
+///
+/// Lives 'static so it can coerce to any `&'a String`. Necessary because Sum's `seed`
+/// runs `wco_join` on salads whose term type is `&'a String` for an `'a` we don't own;
+/// a local `String` declared inside `seed` wouldn't live long enough.
+fn potato() -> &'static String {
+    static POTATO: OnceLock<String> = OnceLock::new();
+    POTATO.get_or_init(|| ".potato".to_string())
+}
+
+/// PlanAtom proxy for virtual relation references — no apparatus, just term info.
+///
+/// `terms` returns the use-site's variable terms; `ground` conservatively returns all
+/// unbound use-site terms (over-claims what the sum can substantiate, which keeps the
+/// planner happy at the cost of possibly suboptimal plans).
+pub struct SumPlan<'a> {
+    pub head_terms: BTreeSet<&'a String>,
+}
+
+impl<'a> PlanAtom<&'a String> for SumPlan<'a> {
+    fn terms(&self) -> BTreeSet<&'a String> { self.head_terms.clone() }
+    fn ground(&self, terms: &BTreeSet<&'a String>) -> BTreeSet<&'a String> {
+        self.head_terms.difference(terms).copied().collect()
+    }
+}
+
+/// One disjunct of a sum: a defining rule plus its pre-built evaluation apparatus.
+pub struct Disjunct<'a> {
+    /// The defining rule (head names the virtual; body is what gets evaluated).
+    pub rule: &'a Rule,
+    /// Plans returned by `plan_rule` for this disjunct's body.
+    pub plans: plan::Plans<usize, &'a String>,
+    /// Loads returned by `plan_rule` for this disjunct's body.
+    pub loads: plan::Loads<usize, &'a String>,
+    /// Pre-built per-driver apparatus for executing the disjunct.
+    pub apparatus: DriverApparatus<'a>,
+}
+
+/// ExecAtom for a virtual relation reference. Holds the use-site atom (for term mapping
+/// to the parent's variables), cached use-site variable terms, and per-disjunct apparatus.
+pub struct Sum<'a> {
+    /// The atom in the parent body that referenced the virtual.
+    pub use_site: &'a Atom,
+    /// Cached use-site variable terms (for `ExecAtom::terms`).
+    pub head_terms: Vec<&'a String>,
+    /// Pre-built apparatus for each defining rule.
+    pub disjuncts: Vec<Disjunct<'a>>,
+}
+
+impl<'a> ExecAtom<&'a String> for Sum<'a> {
+    fn terms(&self) -> &[&'a String] { &self.head_terms[..] }
+
+    fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<&'a String> {
+        let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
+        for disjunct in &self.disjuncts {
+            let disjunct_head = &disjunct.rule.head[0];
+            for ((_plan_atom, plan), (driver, stages)) in disjunct.plans.iter().zip(&disjunct.apparatus) {
+                let mut salad = driver.seed(comms, recent);
+                for ((_, terms, order), others) in plan.iter().zip(stages) {
+                    exec::wco_join(comms, &mut salad, terms, others, potato(), &order[..]);
+                }
+                // Project through the disjunct's head to the use-site's term space.
+                let projected = project_through_head(salad, disjunct_head, self.use_site);
+                result.facts.extend(projected.facts);
+            }
+        }
+        result
+    }
+
+    fn count(&self, _comms: &mut Comms, _salad: &mut Salad<&'a String>, _added: &BTreeSet<&'a String>, _index: u8) {
+        // No-op: sum atoms never propose values during the count protocol. Some other
+        // atom in the join always wins; the sum acts purely as a validator via `join`.
+    }
+
+    fn join(&self, comms: &mut Comms, salad: &mut Salad<&'a String>, added: &BTreeSet<&'a String>, after: &[&'a String]) {
+        // Materialize the sum's full contents and delegate to the data-atom join logic.
+        // This loses the WCOJ-as-participant property — the sum is fully expanded for
+        // every join call — but it lets sums work as non-driver participants in joins.
+        // Optimizing by caching across calls or by genuine count-protocol participation
+        // is future work.
+        let materialized = self.seed(comms, false);
+        let facts: Vec<Forest<Terms>> = materialized.facts.into_iter().collect();
+        let temp: (Vec<Forest<Terms>>, Vec<&'a String>, Option<Forest<Terms>>) =
+            (facts, materialized.terms, None);
+        temp.join(comms, salad, added, after);
+    }
+}
+
+/// Projects a disjunct's result salad to the use-site's term space.
+///
+/// For each position of `use_site.terms`:
+///   * If the corresponding position of `disjunct_head.terms` is `Var(name)`, take the
+///     value from `salad`'s column for that name.
+///   * If it's `Lit(data)`, emit the literal.
+///
+/// The resulting salad's term names are the use-site's variable terms.
+///
+/// Currently asserts the use-site has only variable terms (no literal filters). Lifting
+/// that restriction would require additional filtering by the use-site's literals.
+fn project_through_head<'a>(
+    mut salad: Salad<&'a String>,
+    disjunct_head: &Atom,
+    use_site: &'a Atom,
+) -> Salad<&'a String> {
+    let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
+    assert_eq!(
+        head_terms.len(),
+        use_site.terms.len(),
+        "Sum atom does not yet support literal terms in the use-site atom"
+    );
+    assert_eq!(
+        disjunct_head.terms.len(),
+        use_site.terms.len(),
+        "Disjunct head and use-site atom must have the same arity"
+    );
+
+    let mut action = Action::with_arity(salad.arity());
+    action.projection = disjunct_head.terms.iter().map(|t| match t {
+        Term::Var(name) => Ok(
+            salad.terms.iter().position(|t2| t2.as_str() == name.as_str())
+                .expect("disjunct head var not bound in disjunct's salad")
+        ),
+        Term::Lit(data) => Err(data.clone()),
+    }).collect();
+
+    let thresh = 200_000_000;
+    let mut result_facts: FactLSM<Forest<Terms>> = FactLSM::default();
+    if let Some(flat) = salad.facts.flatten() {
+        result_facts.extend(flat.act_on(&action, thresh));
+    }
+    Salad::new(result_facts, head_terms)
+}

--- a/src/rules/atoms/sum.rs
+++ b/src/rules/atoms/sum.rs
@@ -1,39 +1,31 @@
 //! Sum atom: an `ExecAtom`/`PlanAtom` for virtual relation references.
 //!
-//! When a body atom names a virtual relation (declared via `.decl name(_, _, ...) virtual`),
-//! the planner constructs a `SumPlan` for it (lightweight, no apparatus) and the executor
-//! constructs a `Sum` whose disjuncts are the apparatus pre-built from each defining rule.
-//!
-//! For now: `Sum::seed` evaluates each disjunct, projects through the disjunct's head, and
-//! unions the results. `Sum::count` is a no-op (sum atoms never propose values via the count
-//! protocol). `Sum::join` is not yet implemented — the seeded variant would be needed for
-//! sum atoms in non-driver positions.
+//! `SumPlan` is the lightweight `PlanAtom` used during planning. `Sum` is the
+//! `ExecAtom` constructed for execution; its `seed_disjuncts` and `join_apparatus`
+//! fields are documented on the struct.
 
 use std::collections::BTreeSet;
 use std::sync::OnceLock;
+use std::time::Duration;
 
 use crate::comms::Comms;
-use crate::facts::{FactContainer, FactLSM, Forest, Terms};
-use crate::rules::exec::{self, Salad};
+use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
+use crate::rules::exec::Salad;
 use crate::rules::plan::{self, PlanAtom};
-use crate::rules::{ExecAtom, DriverApparatus};
-use crate::types::{Action, Atom, Rule, Term};
+use crate::rules::{ExecAtom, DriverApparatus, StageBoxes};
+use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
 /// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
 ///
-/// Lives 'static so it can coerce to any `&'a String`. Necessary because Sum's `seed`
-/// runs `wco_join` on salads whose term type is `&'a String` for an `'a` we don't own;
-/// a local `String` declared inside `seed` wouldn't live long enough.
+/// Lives 'static so it can coerce to any `&'a String`. `wco_join` runs on salads
+/// whose term type is `&'a String` for an `'a` we don't own; a local `String`
+/// declared inside `Sum::seed`/`Sum::join_seeded` wouldn't live long enough.
 fn potato() -> &'static String {
     static POTATO: OnceLock<String> = OnceLock::new();
     POTATO.get_or_init(|| ".potato".to_string())
 }
 
 /// PlanAtom proxy for virtual relation references — no apparatus, just term info.
-///
-/// `terms` returns the use-site's variable terms; `ground` conservatively returns all
-/// unbound use-site terms (over-claims what the sum can substantiate, which keeps the
-/// planner happy at the cost of possibly suboptimal plans).
 pub struct SumPlan<'a> {
     pub head_terms: BTreeSet<&'a String>,
 }
@@ -45,27 +37,176 @@ impl<'a> PlanAtom<&'a String> for SumPlan<'a> {
     }
 }
 
-/// One disjunct of a sum: a defining rule plus its pre-built evaluation apparatus.
-pub struct Disjunct<'a> {
-    /// The defining rule (head names the virtual; body is what gets evaluated).
+/// One disjunct of the seed apparatus: defining rule plus its standard apparatus.
+pub struct SeedDisjunct<'a> {
     pub rule: &'a Rule,
-    /// Plans returned by `plan_rule` for this disjunct's body.
     pub plans: plan::Plans<usize, &'a String>,
-    /// Loads returned by `plan_rule` for this disjunct's body.
     pub loads: plan::Loads<usize, &'a String>,
-    /// Pre-built per-driver apparatus for executing the disjunct.
     pub apparatus: DriverApparatus<'a>,
 }
 
-/// ExecAtom for a virtual relation reference. Holds the use-site atom (for term mapping
-/// to the parent's variables), cached use-site variable terms, and per-disjunct apparatus.
+/// One disjunct of the join apparatus: phantom-driven plan + per-stage atoms,
+/// with the variable mapping from use-site space to disjunct head var space.
+pub struct JoinDisjunct<'a> {
+    pub rule: &'a Rule,
+    /// For each pattern term (in use-site space), the disjunct's head var at the
+    /// same position. Always populated for every pattern term: if any pattern
+    /// position had a literal in the disjunct head instead of a var,
+    /// `compute_var_mapping` returns `None` and this disjunct (and the surrounding
+    /// `JoinApparatus`) is never built — `Sum::join` falls back to materialize.
+    pub var_mapping: Vec<(&'a String, &'a String)>,
+    /// The phantom-driven plan stages.
+    pub plan: plan::Plan<usize, &'a String>,
+    /// Pre-built atoms per stage, in plan order (one per atom in each stage).
+    pub stages: Vec<StageBoxes<'a>>,
+}
+
+/// Pre-built apparatus for `Sum::join` for one specific approach pattern.
+pub struct JoinApparatus<'a> {
+    /// The pre-bound subset of sum's terms (in use-site space).
+    pub pattern: BTreeSet<&'a String>,
+    pub disjuncts: Vec<JoinDisjunct<'a>>,
+}
+
+/// ExecAtom for a virtual relation reference.
 pub struct Sum<'a> {
-    /// The atom in the parent body that referenced the virtual.
     pub use_site: &'a Atom,
-    /// Cached use-site variable terms (for `ExecAtom::terms`).
     pub head_terms: Vec<&'a String>,
-    /// Pre-built apparatus for each defining rule.
-    pub disjuncts: Vec<Disjunct<'a>>,
+    /// Apparatus for `seed` (when sum is itself the driver). Always present.
+    pub seed_disjuncts: Vec<SeedDisjunct<'a>>,
+    /// Apparatus for `join` for a single pre-known approach pattern. Present when
+    /// the construction site identified a pattern via the parent plan.
+    pub join_apparatus: Option<JoinApparatus<'a>>,
+}
+
+impl<'a> Sum<'a> {
+    /// Constructs a `Sum` for a virtual reference at `body[load_atom]`.
+    ///
+    /// Always builds the seed apparatus from the virtual relation's defining rules.
+    /// If `parent_plan` is provided (sum used as a non-driver in a join), also
+    /// pre-plans a join apparatus for the inferred approach pattern; if any disjunct
+    /// can't support seeded eval at that pattern, the join apparatus is `None` and
+    /// `Sum::join` falls back to materialize-and-delegate.
+    pub fn build(
+        facts: &mut Relations,
+        comms: &mut Comms,
+        decls: &'a std::collections::BTreeMap<String, RelationDecl>,
+        rules: &'a [(Rule, Vec<Duration>)],
+        body: &'a [Atom],
+        plan_atom: usize,
+        load_atom: usize,
+        parent_plan: Option<&plan::Plan<usize, &'a String>>,
+    ) -> Sum<'a> {
+        let virt_name = body[load_atom].name.as_str();
+        let defining: Vec<&'a Rule> = rules.iter()
+            .map(|(r, _)| r)
+            .filter(|r| !r.head.is_empty() && r.head[0].name.as_str() == virt_name)
+            .collect();
+
+        let mut seed_disjuncts: Vec<SeedDisjunct<'a>> = Vec::with_capacity(defining.len());
+        for rule in &defining {
+            let (plans, loads, apparatus) = crate::rules::plan_and_build_with_fields(
+                facts, comms, decls, rules,
+                &rule.body[..], &rule.head[..],
+                true, None,
+            );
+            seed_disjuncts.push(SeedDisjunct { rule, plans, loads, apparatus });
+        }
+
+        let use_site = &body[load_atom];
+        let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
+
+        let join_apparatus = parent_plan.and_then(|plan| {
+            build_join_apparatus(facts, comms, decls, rules, plan, body, plan_atom, load_atom, &defining, use_site)
+        });
+
+        Sum { use_site, head_terms, seed_disjuncts, join_apparatus }
+    }
+}
+
+/// Computes the approach pattern for a virtual atom in a given (driver, stage) context
+/// and pre-builds a `JoinApparatus` for it. Returns `None` if any disjunct can't
+/// support seeded eval at this pattern (e.g., a disjunct head has a literal at a
+/// pattern position).
+fn build_join_apparatus<'a>(
+    facts: &mut Relations,
+    comms: &mut Comms,
+    decls: &'a std::collections::BTreeMap<String, RelationDecl>,
+    rules: &'a [(Rule, Vec<Duration>)],
+    plan: &plan::Plan<usize, &'a String>,
+    body: &'a [Atom],
+    plan_atom: usize,
+    load_atom: usize,
+    defining: &[&'a Rule],
+    use_site: &'a Atom,
+) -> Option<JoinApparatus<'a>> {
+
+    // Find the stage in `plan` containing `load_atom`.
+    let stage_idx = plan.iter().position(|(stage_atoms, _, _)| stage_atoms.contains(&load_atom))?;
+
+    // Variables bound at the start of stage `stage_idx`: the driver's own terms plus
+    // every prior stage's `terms_to_introduce`.
+    let mut bound_at_stage: BTreeSet<&'a String> =
+        body[plan_atom].terms.iter().filter_map(|t| t.as_var()).collect();
+    for (i, (_, terms_to_intro, _)) in plan.iter().enumerate() {
+        if i >= stage_idx { break; }
+        bound_at_stage.extend(terms_to_intro.iter().copied());
+    }
+
+    let load_terms_set: BTreeSet<&'a String> =
+        body[load_atom].terms.iter().filter_map(|t| t.as_var()).collect();
+
+    let (stage_atoms, stage_terms_to_intro, _) = &plan[stage_idx];
+    // If sum is the sole atom in this stage, it acts as the proposer (count protocol
+    // short-circuits to atom.join with terms). Pattern is sum's terms minus what this
+    // stage introduces. Otherwise sum is a validator and all of sum's terms are bound
+    // by the time `join` is called.
+    let pattern: BTreeSet<&'a String> =
+        if stage_atoms.len() == 1 && stage_atoms.contains(&load_atom) {
+            load_terms_set.difference(stage_terms_to_intro).copied().collect()
+        } else {
+            let mut all_bound = bound_at_stage.clone();
+            all_bound.extend(stage_terms_to_intro.iter().copied());
+            load_terms_set.intersection(&all_bound).copied().collect()
+        };
+
+    // Build per-disjunct join apparatus.
+    let mut disjuncts: Vec<JoinDisjunct<'a>> = Vec::with_capacity(defining.len());
+    for rule in defining {
+        let disjunct_head = &rule.head[0];
+
+        // Compute variable mapping from pattern (use-site) to disjunct head var space.
+        // If the disjunct head has a literal at any pattern position, we can't seed it
+        // without literal-filter support — bail and force the materialize fallback.
+        let var_mapping = compute_var_mapping(&pattern, use_site, disjunct_head)?;
+        let body_pre_bound: BTreeSet<&'a String> =
+            var_mapping.iter().map(|(_, dj)| *dj).collect();
+
+        // Phantom-driven plan for this disjunct's body.
+        let (plan, loads) = plan::plan_rule_seeded::<plan::ByTerm>(
+            &rule.head[..], &rule.body[..], body_pre_bound, decls,
+        ).ok()?;
+
+        // Ensure index actions for each load action in the seeded plan.
+        crate::rules::ensure_actions_for_loads(facts, comms, decls, &rule.body[..], &loads);
+
+        // Build per-stage atoms. Use the disjunct's body atoms as non-drivers (the
+        // input salad acts as the driver). Pass `pattern_info: None` so any nested
+        // virtuals in the disjunct's body fall back to materialize for now.
+        let stages: Vec<StageBoxes<'a>> = plan.iter()
+            .map(|(atoms, _, _)| atoms.iter()
+                .map(|inner_load| crate::rules::build_atom(
+                    facts, comms, decls, rules,
+                    &rule.body[..], 0, *inner_load, &loads,
+                    None,
+                ))
+                .collect::<Vec<_>>())
+            .collect();
+
+        disjuncts.push(JoinDisjunct { rule, var_mapping, plan, stages });
+    }
+
+    Some(JoinApparatus { pattern, disjuncts })
 }
 
 impl<'a> ExecAtom<&'a String> for Sum<'a> {
@@ -73,14 +214,11 @@ impl<'a> ExecAtom<&'a String> for Sum<'a> {
 
     fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<&'a String> {
         let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
-        for disjunct in &self.disjuncts {
+        for disjunct in &self.seed_disjuncts {
             let disjunct_head = &disjunct.rule.head[0];
             for ((_plan_atom, plan), (driver, stages)) in disjunct.plans.iter().zip(&disjunct.apparatus) {
                 let mut salad = driver.seed(comms, recent);
-                for ((_, terms, order), others) in plan.iter().zip(stages) {
-                    exec::wco_join(comms, &mut salad, terms, others, potato(), &order[..]);
-                }
-                // Project through the disjunct's head to the use-site's term space.
+                crate::rules::run_wco_stages(comms, &mut salad, plan, stages, potato());
                 let projected = project_through_head(salad, disjunct_head, self.use_site);
                 result.facts.extend(projected.facts);
             }
@@ -89,16 +227,25 @@ impl<'a> ExecAtom<&'a String> for Sum<'a> {
     }
 
     fn count(&self, _comms: &mut Comms, _salad: &mut Salad<&'a String>, _added: &BTreeSet<&'a String>, _index: u8) {
-        // No-op: sum atoms never propose values during the count protocol. Some other
-        // atom in the join always wins; the sum acts purely as a validator via `join`.
+        // No-op: sum atoms never propose values during the count protocol.
     }
 
     fn join(&self, comms: &mut Comms, salad: &mut Salad<&'a String>, added: &BTreeSet<&'a String>, after: &[&'a String]) {
-        // Materialize the sum's full contents and delegate to the data-atom join logic.
-        // This loses the WCOJ-as-participant property — the sum is fully expanded for
-        // every join call — but it lets sums work as non-driver participants in joins.
-        // Optimizing by caching across calls or by genuine count-protocol participation
-        // is future work.
+        // The call's approach pattern: which sum terms are bound in the input salad,
+        // excluding any that this call is supposed to introduce.
+        let bound_in_salad: BTreeSet<&'a String> = self.head_terms.iter()
+            .filter(|t| salad.terms.contains(*t) && !added.contains(*t))
+            .copied()
+            .collect();
+
+        if let Some(ja) = self.join_apparatus.as_ref() {
+            if ja.pattern == bound_in_salad {
+                self.join_seeded(ja, comms, salad);
+                return;
+            }
+        }
+
+        // Fallback: materialize the full sum and delegate to the data-atom join.
         let materialized = self.seed(comms, false);
         let facts: Vec<Forest<Terms>> = materialized.facts.into_iter().collect();
         let temp: (Vec<Forest<Terms>>, Vec<&'a String>, Option<Forest<Terms>>) =
@@ -107,17 +254,66 @@ impl<'a> ExecAtom<&'a String> for Sum<'a> {
     }
 }
 
+impl<'a> Sum<'a> {
+    /// Seeded-evaluation join: run each disjunct constrained by the input salad,
+    /// project results back to use-site space, replace `salad` with the union.
+    fn join_seeded(&self, ja: &JoinApparatus<'a>, comms: &mut Comms, salad: &mut Salad<&'a String>) {
+        let mut result_facts: FactLSM<Forest<Terms>> = FactLSM::default();
+
+        // Stable iteration order over the pattern; all disjuncts use the same pattern.
+        let pattern_terms: Vec<&'a String> = ja.pattern.iter().copied().collect();
+
+        for disjunct in &ja.disjuncts {
+            let mut disjunct_salad = match project_and_rename(salad, &pattern_terms, &disjunct.var_mapping) {
+                Some(s) => s,
+                None => continue,
+            };
+            crate::rules::run_wco_stages(comms, &mut disjunct_salad, &disjunct.plan, &disjunct.stages, potato());
+            let projected = project_through_head(disjunct_salad, &disjunct.rule.head[0], self.use_site);
+            result_facts.extend(projected.facts);
+        }
+
+        *salad = Salad::new(result_facts, self.head_terms.clone());
+    }
+}
+
+/// Projects input salad onto pattern terms (by column position) and renames each pattern
+/// term from use-site var to the corresponding disjunct head var (per `var_mapping`).
+///
+/// Returns `None` if the input salad is empty (nothing to project).
+fn project_and_rename<'a>(
+    salad: &Salad<&'a String>,
+    pattern_terms: &[&'a String],
+    var_mapping: &[(&'a String, &'a String)],
+) -> Option<Salad<&'a String>> {
+    let projection: Vec<Result<usize, Vec<u8>>> = pattern_terms.iter().map(|us_var| {
+        let col = salad.terms.iter().position(|t| *t == *us_var)
+            .expect("pattern term not in salad");
+        Ok(col)
+    }).collect();
+    let mut action = Action::with_arity(salad.arity());
+    action.projection = projection;
+
+    let thresh = 200_000_000;
+    let mut facts: FactLSM<Forest<Terms>> = FactLSM::default();
+    let mut any = false;
+    for forest in salad.facts.contents() {
+        let projected = forest.act_on(&action, thresh);
+        for f in projected { facts.extend([f]); }
+        any = true;
+    }
+    if !any { return None; }
+
+    // Translate pattern terms to disjunct head var space via var_mapping.
+    let disjunct_terms: Vec<&'a String> = pattern_terms.iter().map(|us_var| {
+        var_mapping.iter().find(|(us, _)| us == us_var).map(|(_, dj)| *dj)
+            .expect("pattern term not in var_mapping")
+    }).collect();
+
+    Some(Salad::new(facts, disjunct_terms))
+}
+
 /// Projects a disjunct's result salad to the use-site's term space.
-///
-/// For each position of `use_site.terms`:
-///   * If the corresponding position of `disjunct_head.terms` is `Var(name)`, take the
-///     value from `salad`'s column for that name.
-///   * If it's `Lit(data)`, emit the literal.
-///
-/// The resulting salad's term names are the use-site's variable terms.
-///
-/// Currently asserts the use-site has only variable terms (no literal filters). Lifting
-/// that restriction would require additional filtering by the use-site's literals.
 fn project_through_head<'a>(
     mut salad: Salad<&'a String>,
     disjunct_head: &Atom,
@@ -150,4 +346,25 @@ fn project_through_head<'a>(
         result_facts.extend(flat.act_on(&action, thresh));
     }
     Salad::new(result_facts, head_terms)
+}
+
+/// Computes the `var_mapping` for a disjunct given a use-site atom and the disjunct's
+/// head atom, restricted to a pattern of pre-bound use-site vars.
+///
+/// Returns `None` if any pattern position has a literal in the disjunct's head (means
+/// seeded eval can't be used for this disjunct without literal-filter support).
+fn compute_var_mapping<'a>(
+    pattern: &BTreeSet<&'a String>,
+    use_site: &'a Atom,
+    disjunct_head: &'a Atom,
+) -> Option<Vec<(&'a String, &'a String)>> {
+    if use_site.terms.len() != disjunct_head.terms.len() { return None; }
+    let mut mapping = Vec::with_capacity(pattern.len());
+    for (us_term, dj_term) in use_site.terms.iter().zip(disjunct_head.terms.iter()) {
+        let us_var = us_term.as_var()?;
+        if !pattern.contains(us_var) { continue; }
+        let dj_var = dj_term.as_var()?;  // None if disjunct head has a Lit here
+        mapping.push((us_var, dj_var));
+    }
+    Some(mapping)
 }

--- a/src/rules/atoms/sum.rs
+++ b/src/rules/atoms/sum.rs
@@ -4,14 +4,14 @@
 //! `ExecAtom` constructed for execution; its `seed_disjuncts` and `join_apparatus`
 //! fields are documented on the struct.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::comms::Comms;
 use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
 use crate::rules::exec::Salad;
-use crate::rules::plan::{self, PlanAtom};
+use crate::rules::plan::{self, PlanAtom, Subst};
 use crate::rules::{ExecAtom, SeedApparatus, StageBoxes};
 use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
@@ -45,18 +45,23 @@ pub struct SeedDisjunct<'a> {
     pub apparatus: SeedApparatus<'a>,
 }
 
-/// One disjunct of the join apparatus: a seeded plan for the disjunct's body, plus
-/// the variable mapping from use-site space to disjunct head var space. The seed is
-/// the caller's salad — projected through `var_mapping` and fed to the plan's stages.
+/// One disjunct of the join apparatus: the seeded plan for the disjunct's body and
+/// the runtime Actions that translate between use-site and disjunct schemas.
+///
+/// At runtime, evaluation is: canonicalize input salad to pattern order → apply
+/// `input_action` → run plan stages → apply `output_action` → use-site-shaped salad.
 pub struct JoinDisjunct<'a> {
     pub rule: &'a Rule,
-    /// For each pattern term (in use-site space), the disjunct's head var at the
-    /// same position. Always populated for every pattern term: if any pattern
-    /// position had a literal in the disjunct head instead of a var,
-    /// `compute_var_mapping` returns `None` and this disjunct (and the surrounding
-    /// `JoinApparatus`) is never built — `Sum::join` falls back to materialize.
-    pub var_mapping: Vec<(&'a String, &'a String)>,
-    /// The seeded plan for the disjunct's body, with the use-site bindings as the seed.
+    /// Applied to the (canonicalized) input salad before passing into the plan.
+    /// Filters by use-site/head-derived constraints not pushable via substitution
+    /// (e.g. head literal at use-site var position in pattern); projects to the
+    /// seed columns.
+    pub input_action: Action<Vec<u8>>,
+    /// Applied to the disjunct's output salad to produce a use-site-shaped salad.
+    /// Projects disjunct columns to use-site var positions and injects literals
+    /// at positions where the (substituted) disjunct head emits constants.
+    pub output_action: Action<Vec<u8>>,
+    /// The seeded plan for the disjunct's body, planned with substitution applied.
     pub plan: plan::Plan<usize, &'a String>,
     /// Pre-built atoms per stage, in plan order (one per atom in each stage).
     pub stages: Vec<StageBoxes<'a>>,
@@ -85,9 +90,11 @@ impl<'a> Sum<'a> {
     ///
     /// Always builds the seed apparatus from the virtual relation's defining rules.
     /// If `parent_plan` is provided (sum used as a non-seed in a join), also
-    /// pre-plans a join apparatus for the inferred approach pattern; if any disjunct
-    /// can't support seeded eval at that pattern, the join apparatus is `None` and
-    /// `Sum::join` falls back to materialize-and-delegate.
+    /// pre-plans a join apparatus for the inferred approach pattern. Per-disjunct
+    /// composition contradictions (lit-vs-lit mismatch, substitution conflict) drop
+    /// that disjunct from the apparatus; `Sum::join` falls back to materialize-and-
+    /// delegate when no `parent_plan` was available or the runtime pattern doesn't
+    /// match the apparatus pattern.
     pub fn build(
         facts: &mut Relations,
         comms: &mut Comms,
@@ -126,9 +133,11 @@ impl<'a> Sum<'a> {
 }
 
 /// Computes the approach pattern for a virtual atom in a given (seed, stage) context
-/// and pre-builds a `JoinApparatus` for it. Returns `None` if any disjunct can't
-/// support seeded eval at this pattern (e.g., a disjunct head has a literal at a
-/// pattern position).
+/// and pre-builds a `JoinApparatus` for it.
+///
+/// Returns `None` if the load atom isn't found in any plan stage. Per-disjunct,
+/// `compose_disjunct` may return `None` (lit-vs-lit contradiction or substitution
+/// conflict) and the disjunct is silently dropped from the apparatus.
 fn build_join_apparatus<'a>(
     facts: &mut Relations,
     comms: &mut Comms,
@@ -157,14 +166,18 @@ fn build_join_apparatus<'a>(
     let load_terms_set: BTreeSet<&'a String> =
         body[load_atom].terms.iter().filter_map(|t| t.as_var()).collect();
 
-    let (stage_atoms, stage_terms_to_intro, _) = &plan[stage_idx];
+    let (stage_atoms, stage_terms_field, _) = &plan[stage_idx];
+    // Stage 0's `terms` field carries seed bindings (pre-bound), not introductions —
+    // see `Plan` doc. For stages 1+, `terms` are the columns that stage introduces.
+    let stage_terms_to_intro: BTreeSet<&'a String> =
+        if stage_idx == 0 { BTreeSet::default() } else { stage_terms_field.clone() };
     // If sum is the sole atom in this stage, it acts as the proposer (count protocol
     // short-circuits to atom.join with terms). Pattern is sum's terms minus what this
     // stage introduces. Otherwise sum is a validator and all of sum's terms are bound
     // by the time `join` is called.
     let pattern: BTreeSet<&'a String> =
         if stage_atoms.len() == 1 && stage_atoms.contains(&load_atom) {
-            load_terms_set.difference(stage_terms_to_intro).copied().collect()
+            load_terms_set.difference(&stage_terms_to_intro).copied().collect()
         } else {
             let mut all_bound = bound_at_stage.clone();
             all_bound.extend(stage_terms_to_intro.iter().copied());
@@ -176,32 +189,41 @@ fn build_join_apparatus<'a>(
     for rule in defining {
         let disjunct_head = &rule.head[0];
 
-        // Compute variable mapping from pattern (use-site) to disjunct head var space.
-        // If the disjunct head has a literal at any pattern position, we can't seed it
-        // without literal-filter support — bail and force the materialize fallback.
-        let var_mapping = compute_var_mapping(&pattern, use_site, disjunct_head)?;
-        let body_pre_bound: Vec<&'a String> =
-            var_mapping.iter().map(|(_, dj)| *dj).collect();
+        // Compose use-site request with this disjunct's head. `None` means the
+        // disjunct contributes nothing (lit-vs-lit contradiction or substitution
+        // conflict) — we silently skip it.
+        let comp = match compose_disjunct(&pattern, use_site, disjunct_head) {
+            Some(c) => c,
+            None => continue,
+        };
 
-        let (plan, loads) = plan::plan_rule_seeded(&rule.head[0], &rule.body[..], &body_pre_bound, decls);
+        let (plan, loads) = plan::plan_rule_seeded(
+            &rule.body[..], &comp.seed, &comp.need, &comp.subst, decls,
+        );
 
         // Ensure index actions for each load action in the seeded plan.
         crate::rules::ensure_actions_for_loads(facts, comms, decls, &rule.body[..], &loads);
 
-        // Build per-stage atoms. Use the disjunct's body atoms as non-seeds (the
-        // input salad acts as the seed). Pass `pattern_info: None` so any nested
-        // virtuals in the disjunct's body fall back to materialize for now.
+        // Build per-stage atoms. Pass `pattern_info: None` so any nested virtuals
+        // in the disjunct's body fall back to materialize for now.
         let stages: Vec<StageBoxes<'a>> = plan.iter()
             .map(|(atoms, _, _)| atoms.iter()
                 .map(|inner_load| crate::rules::build_atom(
                     facts, comms, decls, rules,
                     &rule.body[..], 0, *inner_load, &loads,
                     None,
+                    &comp.subst,
                 ))
                 .collect::<Vec<_>>())
             .collect();
 
-        disjuncts.push(JoinDisjunct { rule, var_mapping, plan, stages });
+        disjuncts.push(JoinDisjunct {
+            rule,
+            input_action: comp.input_action,
+            output_action: comp.output_action,
+            plan,
+            stages,
+        });
     }
 
     Some(JoinApparatus { pattern, disjuncts })
@@ -261,13 +283,24 @@ impl<'a> Sum<'a> {
         // Stable iteration order over the pattern; all disjuncts use the same pattern.
         let pattern_terms: Vec<&'a String> = ja.pattern.iter().copied().collect();
 
+        // Canonicalize input salad to pattern-term order. Each disjunct's `input_action`
+        // assumes columns are in this order.
+        let canonical = match canonicalize_salad(salad, &pattern_terms) {
+            Some(s) => s,
+            None => { *salad = Salad::new(FactLSM::default(), self.head_terms.clone()); return; }
+        };
+
         for disjunct in &ja.disjuncts {
-            let mut disjunct_salad = match project_and_rename(salad, &pattern_terms, &disjunct.var_mapping) {
-                Some(s) => s,
-                None => continue,
-            };
-            crate::rules::run_wco_stages(comms, &mut disjunct_salad, &disjunct.plan, &disjunct.stages, potato());
-            let projected = project_through_head(disjunct_salad, &disjunct.rule.head[0], self.use_site);
+            let mut disjunct_salad = apply_action_to_salad(
+                &canonical, &disjunct.input_action, disjunct.seed_terms_for_action(),
+            );
+            if disjunct_salad.facts.is_empty() { continue; }
+            crate::rules::run_wco_stages(
+                comms, &mut disjunct_salad, &disjunct.plan, &disjunct.stages, potato(),
+            );
+            let projected = apply_action_to_salad(
+                &disjunct_salad, &disjunct.output_action, self.head_terms.clone(),
+            );
             result_facts.extend(projected.facts);
         }
 
@@ -275,18 +308,25 @@ impl<'a> Sum<'a> {
     }
 }
 
-/// Projects input salad onto pattern terms (by column position) and renames each pattern
-/// term from use-site var to the corresponding disjunct head var (per `var_mapping`).
-///
-/// Returns `None` if the input salad is empty (nothing to project).
-fn project_and_rename<'a>(
+impl<'a> JoinDisjunct<'a> {
+    /// Term names corresponding to the columns `input_action` projects to. Computed
+    /// from the plan's stage 0 terms — that's where the seed lands.
+    fn seed_terms_for_action(&self) -> Vec<&'a String> {
+        self.plan.first()
+            .map(|(_, terms, _)| terms.iter().copied().collect())
+            .unwrap_or_default()
+    }
+}
+
+/// Projects input salad onto `target_terms` by column position. Returns `None` if
+/// the salad is empty.
+fn canonicalize_salad<'a>(
     salad: &Salad<&'a String>,
-    pattern_terms: &[&'a String],
-    var_mapping: &[(&'a String, &'a String)],
+    target_terms: &[&'a String],
 ) -> Option<Salad<&'a String>> {
-    let projection: Vec<Result<usize, Vec<u8>>> = pattern_terms.iter().map(|us_var| {
-        let col = salad.terms.iter().position(|t| *t == *us_var)
-            .expect("pattern term not in salad");
+    let projection: Vec<Result<usize, Vec<u8>>> = target_terms.iter().map(|t| {
+        let col = salad.terms.iter().position(|s| *s == *t)
+            .expect("target term not in salad");
         Ok(col)
     }).collect();
     let mut action = Action::with_arity(salad.arity());
@@ -296,47 +336,78 @@ fn project_and_rename<'a>(
     let mut facts: FactLSM<Forest<Terms>> = FactLSM::default();
     let mut any = false;
     for forest in salad.facts.contents() {
-        let projected = forest.act_on(&action, thresh);
-        for f in projected { facts.extend([f]); }
+        for f in forest.act_on(&action, thresh) { facts.extend([f]); }
         any = true;
     }
     if !any { return None; }
 
-    // Translate pattern terms to disjunct head var space via var_mapping.
-    let disjunct_terms: Vec<&'a String> = pattern_terms.iter().map(|us_var| {
-        var_mapping.iter().find(|(us, _)| us == us_var).map(|(_, dj)| *dj)
-            .expect("pattern term not in var_mapping")
-    }).collect();
+    Some(Salad::new(facts, target_terms.to_vec()))
+}
 
-    Some(Salad::new(facts, disjunct_terms))
+/// Applies an Action to a salad, producing a new salad with the given `output_terms`.
+fn apply_action_to_salad<'a>(
+    salad: &Salad<&'a String>,
+    action: &Action<Vec<u8>>,
+    output_terms: Vec<&'a String>,
+) -> Salad<&'a String> {
+    let thresh = 200_000_000;
+    let mut facts: FactLSM<Forest<Terms>> = FactLSM::default();
+    for forest in salad.facts.contents() {
+        for f in forest.act_on(action, thresh) { facts.extend([f]); }
+    }
+    Salad::new(facts, output_terms)
 }
 
 /// Projects a disjunct's result salad to the use-site's term space.
+///
+/// Walks (use_site_term, disjunct_head_term) position-by-position:
+/// - (Var Vu, Var Vd): emit the salad column for Vd at output position (labeled Vu).
+/// - (Var Vu, Lit Ld): emit Ld as a constant column at output position (labeled Vu).
+/// - (Lit Lu, Var Vd): filter rows where the salad's Vd column equals Lu; don't emit
+///   (use-site lit isn't a column in the output salad).
+/// - (Lit Lu, Lit Ld): if equal, no-op; if not, the disjunct contributes nothing
+///   (return empty salad with use-site var schema).
+///
+/// This is the no-substitution counterpart to `compose_disjunct`'s `output_action`,
+/// used by `Sum::seed` (which materializes the full virtual relation without seeded
+/// pushdown — see `seed_disjuncts`).
 fn project_through_head<'a>(
     mut salad: Salad<&'a String>,
     disjunct_head: &Atom,
     use_site: &'a Atom,
 ) -> Salad<&'a String> {
-    let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
-    assert_eq!(
-        head_terms.len(),
-        use_site.terms.len(),
-        "Sum atom does not yet support literal terms in the use-site atom"
-    );
     assert_eq!(
         disjunct_head.terms.len(),
         use_site.terms.len(),
         "Disjunct head and use-site atom must have the same arity"
     );
 
+    let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
     let mut action = Action::with_arity(salad.arity());
-    action.projection = disjunct_head.terms.iter().map(|t| match t {
-        Term::Var(name) => Ok(
-            salad.terms.iter().position(|t2| t2.as_str() == name.as_str())
-                .expect("disjunct head var not bound in disjunct's salad")
-        ),
-        Term::Lit(data) => Err(data.clone()),
-    }).collect();
+    for (us_term, dj_term) in use_site.terms.iter().zip(disjunct_head.terms.iter()) {
+        match (us_term, dj_term) {
+            (Term::Var(_), Term::Var(vd)) => {
+                let col = salad.terms.iter().position(|t| t.as_str() == vd.as_str())
+                    .expect("disjunct head var not bound in disjunct's salad");
+                action.projection.push(Ok(col));
+            }
+            (Term::Var(_), Term::Lit(ld)) => {
+                action.projection.push(Err(ld.clone()));
+            }
+            (Term::Lit(lu), Term::Var(vd)) => {
+                let col = salad.terms.iter().position(|t| t.as_str() == vd.as_str())
+                    .expect("disjunct head var not bound in disjunct's salad");
+                action.lit_filter.push((col, lu.clone()));
+                // No projection entry — use-site lit doesn't appear in output salad.
+            }
+            (Term::Lit(lu), Term::Lit(ld)) => {
+                if lu != ld {
+                    return Salad::new(FactLSM::default(), head_terms);
+                }
+                // else: matching lits — no-op.
+            }
+        }
+    }
 
     let thresh = 200_000_000;
     let mut result_facts: FactLSM<Forest<Terms>> = FactLSM::default();
@@ -346,23 +417,166 @@ fn project_through_head<'a>(
     Salad::new(result_facts, head_terms)
 }
 
-/// Computes the `var_mapping` for a disjunct given a use-site atom and the disjunct's
-/// head atom, restricted to a pattern of pre-bound use-site vars.
+/// The runtime-ready result of composing a use-site request with one disjunct's head.
 ///
-/// Returns `None` if any pattern position has a literal in the disjunct's head (means
-/// seeded eval can't be used for this disjunct without literal-filter support).
-fn compute_var_mapping<'a>(
+/// Each field carries information for a different lifecycle:
+/// - `subst`: planning-time substitution (body var → use-site var or literal). Fed to
+///   `plan_rule_seeded`; consumed there to bias `build_atoms_map` and `base_actions_for`
+///   without rewriting the body's `Atom` structs.
+/// - `seed`: pre-bound terms (use-site vars in pattern, in BTreeSet order). Fed to
+///   `plan_rule_seeded` as its seed slice.
+/// - `need`: live disjunct vars that the use-site actually consumes (substituted-head
+///   distinct vars filtered to those `output_action` references). Fed to
+///   `plan_rule_seeded` as the last-stage projection target — terms in the substituted
+///   head but not in `need` are dead from the use-site's perspective and get dropped
+///   by `plan_body`'s projection-target loop.
+/// - `input_action`: runtime Action applied to the input salad (columns in pattern
+///   BTreeSet order) before passing to the disjunct. Filters by use-site/head
+///   constraints not pushable via subst; projects to seed columns.
+/// - `output_action`: runtime Action applied to the disjunct's output salad to
+///   produce a use-site-shaped salad. Its `Ok(col)` projection entries index into
+///   `need`-order (the disjunct salad's actual column order after projection-pushdown).
+struct DisjunctComposition<'a> {
+    subst: Subst<'a>,
+    seed: Vec<&'a String>,
+    need: Vec<&'a String>,
+    input_action: Action<Vec<u8>>,
+    output_action: Action<Vec<u8>>,
+}
+
+/// Composes a use-site request with one disjunct's head, producing the recipe for
+/// evaluating the disjunct in service of the use-site.
+///
+/// Walks position-by-position through (use_site, disjunct_head). Each pair contributes
+/// to the substitution (when the head term is a var that can be rewritten), to the
+/// input filter (when the head term is a lit and the use-site var is in pattern), or
+/// to a contradiction (lit vs. lit mismatch, or substitution conflict — the latter
+/// arises when the head has a repeated var and the use-site disagrees, which v1 bails
+/// on rather than emitting an `input_action.var_filter`).
+///
+/// Returns `None` for arity mismatch, lit-vs-lit contradictions, or substitution
+/// conflicts.
+fn compose_disjunct<'a>(
     pattern: &BTreeSet<&'a String>,
     use_site: &'a Atom,
     disjunct_head: &'a Atom,
-) -> Option<Vec<(&'a String, &'a String)>> {
+) -> Option<DisjunctComposition<'a>> {
     if use_site.terms.len() != disjunct_head.terms.len() { return None; }
-    let mut mapping = Vec::with_capacity(pattern.len());
+
+    // Pass 1: build the substitution and collect input lit filters.
+    let mut subst: Subst<'a> = BTreeMap::new();
+    let mut input_lits: Vec<(&'a String, &'a Vec<u8>)> = Vec::new();
+
     for (us_term, dj_term) in use_site.terms.iter().zip(disjunct_head.terms.iter()) {
-        let us_var = us_term.as_var()?;
-        if !pattern.contains(us_var) { continue; }
-        let dj_var = dj_term.as_var()?;  // None if disjunct head has a Lit here
-        mapping.push((us_var, dj_var));
+        match (us_term, dj_term) {
+            (Term::Var(vu), Term::Var(vd)) => {
+                // Substitute disjunct var with use-site var.
+                match subst.get(vd) {
+                    Some(Term::Var(prev)) if prev != vu => return None,
+                    Some(Term::Lit(_)) => return None,
+                    _ => { subst.insert(vd, us_term); }
+                }
+            }
+            (Term::Var(vu), Term::Lit(ld)) => {
+                if pattern.contains(vu) {
+                    input_lits.push((vu, ld));
+                }
+                // Else: vu is not pre-bound; gets bound to ld at output via output_action.
+            }
+            (Term::Lit(lu), Term::Var(vd)) => {
+                // Push literal into the disjunct's body planning via substitution.
+                match subst.get(vd) {
+                    Some(Term::Lit(prev)) if prev != lu => return None,
+                    Some(Term::Var(_)) => return None,
+                    _ => { subst.insert(vd, us_term); }
+                }
+            }
+            (Term::Lit(lu), Term::Lit(ld)) => {
+                if lu != ld { return None; }
+            }
+        }
     }
-    Some(mapping)
+
+    // Seed: all pattern vars (BTreeSet order). `plan_body` filters out vars unused
+    // by the (substituted) body via its `init_terms` step.
+    let seed: Vec<&'a String> = pattern.iter().copied().collect();
+
+    // Build input_action. Assumes the input salad has been canonicalized to
+    // pattern-term order (BTreeSet iteration). Filters by collected lits, projects
+    // to the seed columns.
+    let pattern_terms: Vec<&'a String> = pattern.iter().copied().collect();
+    let mut input_action = Action::with_arity(pattern_terms.len());
+    for (vu, ld) in &input_lits {
+        let col = pattern_terms.iter().position(|t| *t == *vu)
+            .expect("input lit on var not in pattern");
+        input_action.lit_filter.push((col, (*ld).clone()));
+    }
+    input_action.projection = seed.iter().map(|s| {
+        Ok(pattern_terms.iter().position(|t| *t == *s)
+            .expect("seed var not in pattern"))
+    }).collect();
+
+    // Determine which substituted-head vars are *live* — referenced by some use-site
+    // var position. Vars in the substituted head but not live are dead from the
+    // use-site's perspective; `plan_body` will drop them in its last-stage projection.
+    let mut live: BTreeSet<&'a String> = BTreeSet::default();
+    for (i, us_term) in use_site.terms.iter().enumerate() {
+        if let Term::Var(_) = us_term {
+            if let Term::Var(vd) = &disjunct_head.terms[i] {
+                let effective: Option<&'a String> = match subst.get(vd) {
+                    Some(Term::Var(new_name)) => Some(new_name),
+                    Some(Term::Lit(_)) => None,
+                    None => Some(vd),
+                };
+                if let Some(n) = effective { live.insert(n); }
+            }
+        }
+    }
+    // `need`: substituted head's distinct vars in presentation order, filtered to live.
+    let need: Vec<&'a String> = {
+        let mut seen: BTreeSet<&'a String> = BTreeSet::default();
+        let mut out: Vec<&'a String> = Vec::new();
+        for t in disjunct_head.terms.iter() {
+            if let Term::Var(name) = t {
+                let effective: Option<&'a String> = match subst.get(name) {
+                    Some(Term::Var(new_name)) => Some(new_name),
+                    Some(Term::Lit(_)) => None,
+                    None => Some(name),
+                };
+                if let Some(n) = effective {
+                    if live.contains(n) && seen.insert(n) { out.push(n); }
+                }
+            }
+        }
+        out
+    };
+
+    // Build output_action. Disjunct salad columns (after the plan applies `need` as
+    // the last-stage projection) are in `need` order. For each use-site var position,
+    // emit `Ok(col)` indexed into `need`, or `Err(lit)` for emitted literals.
+    let mut output_action = Action::with_arity(need.len());
+    for (i, us_term) in use_site.terms.iter().enumerate() {
+        if let Term::Var(_) = us_term {
+            let emit: Result<usize, Vec<u8>> = match &disjunct_head.terms[i] {
+                Term::Var(vd) => match subst.get(vd) {
+                    Some(Term::Var(new_name)) => {
+                        let col = need.iter().position(|t| *t as &String == new_name as &String)
+                            .expect("substituted var not in need");
+                        Ok(col)
+                    }
+                    Some(Term::Lit(value)) => Err(value.clone()),
+                    None => {
+                        let col = need.iter().position(|t| *t as &String == vd as &String)
+                            .expect("disjunct head var not in need");
+                        Ok(col)
+                    }
+                },
+                Term::Lit(value) => Err(value.clone()),
+            };
+            output_action.projection.push(emit);
+        }
+    }
+
+    Some(DisjunctComposition { subst, seed, need, input_action, output_action })
 }
+

--- a/src/rules/atoms/sum.rs
+++ b/src/rules/atoms/sum.rs
@@ -12,7 +12,7 @@ use crate::comms::Comms;
 use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
 use crate::rules::exec::Salad;
 use crate::rules::plan::{self, PlanAtom};
-use crate::rules::{ExecAtom, DriverApparatus, StageBoxes};
+use crate::rules::{ExecAtom, SeedApparatus, StageBoxes};
 use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
 /// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
@@ -42,7 +42,7 @@ pub struct SeedDisjunct<'a> {
     pub rule: &'a Rule,
     pub plans: plan::Plans<usize, &'a String>,
     pub loads: plan::Loads<usize, &'a String>,
-    pub apparatus: DriverApparatus<'a>,
+    pub apparatus: SeedApparatus<'a>,
 }
 
 /// One disjunct of the join apparatus: phantom-driven plan + per-stage atoms,
@@ -72,7 +72,7 @@ pub struct JoinApparatus<'a> {
 pub struct Sum<'a> {
     pub use_site: &'a Atom,
     pub head_terms: Vec<&'a String>,
-    /// Apparatus for `seed` (when sum is itself the driver). Always present.
+    /// Apparatus for `seed` (when sum is itself the seed). Always present.
     pub seed_disjuncts: Vec<SeedDisjunct<'a>>,
     /// Apparatus for `join` for a single pre-known approach pattern. Present when
     /// the construction site identified a pattern via the parent plan.
@@ -83,7 +83,7 @@ impl<'a> Sum<'a> {
     /// Constructs a `Sum` for a virtual reference at `body[load_atom]`.
     ///
     /// Always builds the seed apparatus from the virtual relation's defining rules.
-    /// If `parent_plan` is provided (sum used as a non-driver in a join), also
+    /// If `parent_plan` is provided (sum used as a non-seed in a join), also
     /// pre-plans a join apparatus for the inferred approach pattern; if any disjunct
     /// can't support seeded eval at that pattern, the join apparatus is `None` and
     /// `Sum::join` falls back to materialize-and-delegate.
@@ -124,7 +124,7 @@ impl<'a> Sum<'a> {
     }
 }
 
-/// Computes the approach pattern for a virtual atom in a given (driver, stage) context
+/// Computes the approach pattern for a virtual atom in a given (seed, stage) context
 /// and pre-builds a `JoinApparatus` for it. Returns `None` if any disjunct can't
 /// support seeded eval at this pattern (e.g., a disjunct head has a literal at a
 /// pattern position).
@@ -144,7 +144,7 @@ fn build_join_apparatus<'a>(
     // Find the stage in `plan` containing `load_atom`.
     let stage_idx = plan.iter().position(|(stage_atoms, _, _)| stage_atoms.contains(&load_atom))?;
 
-    // Variables bound at the start of stage `stage_idx`: the driver's own terms plus
+    // Variables bound at the start of stage `stage_idx`: the seed's own terms plus
     // every prior stage's `terms_to_introduce`.
     let mut bound_at_stage: BTreeSet<&'a String> =
         body[plan_atom].terms.iter().filter_map(|t| t.as_var()).collect();
@@ -179,19 +179,16 @@ fn build_join_apparatus<'a>(
         // If the disjunct head has a literal at any pattern position, we can't seed it
         // without literal-filter support — bail and force the materialize fallback.
         let var_mapping = compute_var_mapping(&pattern, use_site, disjunct_head)?;
-        let body_pre_bound: BTreeSet<&'a String> =
+        let body_pre_bound: Vec<&'a String> =
             var_mapping.iter().map(|(_, dj)| *dj).collect();
 
-        // Phantom-driven plan for this disjunct's body.
-        let (plan, loads) = plan::plan_rule_seeded::<plan::ByTerm>(
-            &rule.head[..], &rule.body[..], body_pre_bound, decls,
-        ).ok()?;
+        let (plan, loads) = plan::plan_rule_seeded(&rule.head[0], &rule.body[..], &body_pre_bound, decls);
 
         // Ensure index actions for each load action in the seeded plan.
         crate::rules::ensure_actions_for_loads(facts, comms, decls, &rule.body[..], &loads);
 
-        // Build per-stage atoms. Use the disjunct's body atoms as non-drivers (the
-        // input salad acts as the driver). Pass `pattern_info: None` so any nested
+        // Build per-stage atoms. Use the disjunct's body atoms as non-seeds (the
+        // input salad acts as the seed). Pass `pattern_info: None` so any nested
         // virtuals in the disjunct's body fall back to materialize for now.
         let stages: Vec<StageBoxes<'a>> = plan.iter()
             .map(|(atoms, _, _)| atoms.iter()

--- a/src/rules/atoms/sum.rs
+++ b/src/rules/atoms/sum.rs
@@ -45,8 +45,9 @@ pub struct SeedDisjunct<'a> {
     pub apparatus: SeedApparatus<'a>,
 }
 
-/// One disjunct of the join apparatus: phantom-driven plan + per-stage atoms,
-/// with the variable mapping from use-site space to disjunct head var space.
+/// One disjunct of the join apparatus: a seeded plan for the disjunct's body, plus
+/// the variable mapping from use-site space to disjunct head var space. The seed is
+/// the caller's salad — projected through `var_mapping` and fed to the plan's stages.
 pub struct JoinDisjunct<'a> {
     pub rule: &'a Rule,
     /// For each pattern term (in use-site space), the disjunct's head var at the
@@ -55,7 +56,7 @@ pub struct JoinDisjunct<'a> {
     /// `compute_var_mapping` returns `None` and this disjunct (and the surrounding
     /// `JoinApparatus`) is never built — `Sum::join` falls back to materialize.
     pub var_mapping: Vec<(&'a String, &'a String)>,
-    /// The phantom-driven plan stages.
+    /// The seeded plan for the disjunct's body, with the use-site bindings as the seed.
     pub plan: plan::Plan<usize, &'a String>,
     /// Pre-built atoms per stage, in plan order (one per atom in each stage).
     pub stages: Vec<StageBoxes<'a>>,

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -1,6 +1,7 @@
-//! Sum atom: an `ExecAtom`/`PlanAtom` for virtual relation references.
+//! View atom: an `ExecAtom`/`PlanAtom` for view references (computed-on-demand
+//! relations declared via `.decl name(_, _) view`).
 //!
-//! `SumPlan` is the lightweight `PlanAtom` used during planning. `Sum` is the
+//! `ViewPlan` is the lightweight `PlanAtom` used during planning. `View` is the
 //! `ExecAtom` constructed for execution; its `seed_disjuncts` and `join_apparatus`
 //! fields are documented on the struct.
 
@@ -19,18 +20,18 @@ use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 ///
 /// Lives 'static so it can coerce to any `&'a String`. `wco_join` runs on salads
 /// whose term type is `&'a String` for an `'a` we don't own; a local `String`
-/// declared inside `Sum::seed`/`Sum::join_seeded` wouldn't live long enough.
+/// declared inside `View::seed`/`View::join_seeded` wouldn't live long enough.
 fn potato() -> &'static String {
     static POTATO: OnceLock<String> = OnceLock::new();
     POTATO.get_or_init(|| ".potato".to_string())
 }
 
-/// PlanAtom proxy for virtual relation references — no apparatus, just term info.
-pub struct SumPlan<'a> {
+/// PlanAtom proxy for view references — no apparatus, just term info.
+pub struct ViewPlan<'a> {
     pub head_terms: BTreeSet<&'a String>,
 }
 
-impl<'a> PlanAtom<&'a String> for SumPlan<'a> {
+impl<'a> PlanAtom<&'a String> for ViewPlan<'a> {
     fn terms(&self) -> BTreeSet<&'a String> { self.head_terms.clone() }
     fn ground(&self, terms: &BTreeSet<&'a String>) -> BTreeSet<&'a String> {
         self.head_terms.difference(terms).copied().collect()
@@ -67,15 +68,15 @@ pub struct JoinDisjunct<'a> {
     pub stages: Vec<StageBoxes<'a>>,
 }
 
-/// Pre-built apparatus for `Sum::join` for one specific approach pattern.
+/// Pre-built apparatus for `View::join` for one specific approach pattern.
 pub struct JoinApparatus<'a> {
     /// The pre-bound subset of sum's terms (in use-site space).
     pub pattern: BTreeSet<&'a String>,
     pub disjuncts: Vec<JoinDisjunct<'a>>,
 }
 
-/// ExecAtom for a virtual relation reference.
-pub struct Sum<'a> {
+/// ExecAtom for a view reference.
+pub struct View<'a> {
     pub use_site: &'a Atom,
     pub head_terms: Vec<&'a String>,
     /// Apparatus for `seed` (when sum is itself the seed). Always present.
@@ -85,14 +86,14 @@ pub struct Sum<'a> {
     pub join_apparatus: Option<JoinApparatus<'a>>,
 }
 
-impl<'a> Sum<'a> {
-    /// Constructs a `Sum` for a virtual reference at `body[load_atom]`.
+impl<'a> View<'a> {
+    /// Constructs a `View` for a view reference at `body[load_atom]`.
     ///
-    /// Always builds the seed apparatus from the virtual relation's defining rules.
-    /// If `parent_plan` is provided (sum used as a non-seed in a join), also
+    /// Always builds the seed apparatus from the view's defining rules.
+    /// If `parent_plan` is provided (view used as a non-seed in a join), also
     /// pre-plans a join apparatus for the inferred approach pattern. Per-disjunct
     /// composition contradictions (lit-vs-lit mismatch, substitution conflict) drop
-    /// that disjunct from the apparatus; `Sum::join` falls back to materialize-and-
+    /// that disjunct from the apparatus; `View::join` falls back to materialize-and-
     /// delegate when no `parent_plan` was available or the runtime pattern doesn't
     /// match the apparatus pattern.
     pub fn build(
@@ -104,11 +105,11 @@ impl<'a> Sum<'a> {
         plan_atom: usize,
         load_atom: usize,
         parent_plan: Option<&plan::Plan<usize, &'a String>>,
-    ) -> Sum<'a> {
-        let virt_name = body[load_atom].name.as_str();
+    ) -> View<'a> {
+        let view_name = body[load_atom].name.as_str();
         let defining: Vec<&'a Rule> = rules.iter()
             .map(|(r, _)| r)
-            .filter(|r| !r.head.is_empty() && r.head[0].name.as_str() == virt_name)
+            .filter(|r| !r.head.is_empty() && r.head[0].name.as_str() == view_name)
             .collect();
 
         let mut seed_disjuncts: Vec<SeedDisjunct<'a>> = Vec::with_capacity(defining.len());
@@ -128,11 +129,11 @@ impl<'a> Sum<'a> {
             build_join_apparatus(facts, comms, decls, rules, plan, body, plan_atom, load_atom, &defining, use_site)
         });
 
-        Sum { use_site, head_terms, seed_disjuncts, join_apparatus }
+        View { use_site, head_terms, seed_disjuncts, join_apparatus }
     }
 }
 
-/// Computes the approach pattern for a virtual atom in a given (seed, stage) context
+/// Computes the approach pattern for a view atom in a given (seed, stage) context
 /// and pre-builds a `JoinApparatus` for it.
 ///
 /// Returns `None` if the load atom isn't found in any plan stage. Per-disjunct,
@@ -204,7 +205,7 @@ fn build_join_apparatus<'a>(
         // Ensure index actions for each load action in the seeded plan.
         crate::rules::ensure_actions_for_loads(facts, comms, decls, &rule.body[..], &loads);
 
-        // Build per-stage atoms. Pass `pattern_info: None` so any nested virtuals
+        // Build per-stage atoms. Pass `pattern_info: None` so any nested views
         // in the disjunct's body fall back to materialize for now.
         let stages: Vec<StageBoxes<'a>> = plan.iter()
             .map(|(atoms, _, _)| atoms.iter()
@@ -229,7 +230,7 @@ fn build_join_apparatus<'a>(
     Some(JoinApparatus { pattern, disjuncts })
 }
 
-impl<'a> ExecAtom<&'a String> for Sum<'a> {
+impl<'a> ExecAtom<&'a String> for View<'a> {
     fn terms(&self) -> &[&'a String] { &self.head_terms[..] }
 
     fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<&'a String> {
@@ -247,7 +248,7 @@ impl<'a> ExecAtom<&'a String> for Sum<'a> {
     }
 
     fn count(&self, _comms: &mut Comms, _salad: &mut Salad<&'a String>, _added: &BTreeSet<&'a String>, _index: u8) {
-        // No-op: sum atoms never propose values during the count protocol.
+        // No-op: view atoms never propose values during the count protocol.
     }
 
     fn join(&self, comms: &mut Comms, salad: &mut Salad<&'a String>, added: &BTreeSet<&'a String>, after: &[&'a String]) {
@@ -274,7 +275,7 @@ impl<'a> ExecAtom<&'a String> for Sum<'a> {
     }
 }
 
-impl<'a> Sum<'a> {
+impl<'a> View<'a> {
     /// Seeded-evaluation join: run each disjunct constrained by the input salad,
     /// project results back to use-site space, replace `salad` with the union.
     fn join_seeded(&self, ja: &JoinApparatus<'a>, comms: &mut Comms, salad: &mut Salad<&'a String>) {
@@ -369,7 +370,7 @@ fn apply_action_to_salad<'a>(
 ///   (return empty salad with use-site var schema).
 ///
 /// This is the no-substitution counterpart to `compose_disjunct`'s `output_action`,
-/// used by `Sum::seed` (which materializes the full virtual relation without seeded
+/// used by `View::seed` (which materializes the full view without seeded
 /// pushdown — see `seed_disjuncts`).
 fn project_through_head<'a>(
     mut salad: Salad<&'a String>,

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -26,13 +26,13 @@ pub use exec::ExecAtom;
 
 /// Constructs a boxed `ExecAtom` for an atom in a rule body.
 ///
-/// Dispatches between logic, virtual (sum), antijoin, and data variants based on the
+/// Dispatches between logic, view, antijoin, and data variants based on the
 /// atom's name and the declarations. For data atoms, threads the appropriate
-/// stable/recent split per the semi-naive convention. For virtual atoms, delegates
-/// to `Sum::build`.
+/// stable/recent split per the semi-naive convention. For view atoms, delegates
+/// to `View::build`.
 ///
 /// `parent_plan` is the surrounding rule's plan for this seed, threaded through so
-/// virtual atoms can compute their approach pattern from where they appear. `None`
+/// view atoms can compute their approach pattern from where they appear. `None`
 /// means the atom is itself the seed (no surrounding plan to inspect).
 pub(crate) fn build_atom<'a>(
     facts: &mut Relations,
@@ -49,8 +49,8 @@ pub(crate) fn build_atom<'a>(
     use crate::rules::atoms;
     if let Some(logic) = atoms::logic::resolve_with_subst(&body[load_atom], subst) {
         Box::new(logic)
-    } else if decls.get(body[load_atom].name.as_str()).map_or(false, |d| d.virt) {
-        Box::new(atoms::sum::Sum::build(
+    } else if decls.get(body[load_atom].name.as_str()).map_or(false, |d| d.view) {
+        Box::new(atoms::view::View::build(
             facts, comms, decls, rules, body, plan_atom, load_atom, parent_plan,
         ))
     } else {
@@ -77,10 +77,10 @@ type SeedApparatus<'a> = Vec<SeedWork<'a>>;
 
 /// Plans a rule body and pre-builds the boxed atoms for every (seed, stage).
 ///
-/// Lives as a free function (not a method) because virtual references recursively
+/// Lives as a free function (not a method) because view references recursively
 /// invoke this with the same field borrows. Callers split a `&mut State` into its
 /// fields and pass them through. `rules` is the State's rule list, used to look up
-/// virtual relations' defining rules during sum-atom construction.
+/// views' defining rules during view-atom construction.
 pub fn plan_and_build_with_fields<'a>(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
@@ -201,7 +201,7 @@ fn emit_head_facts<'a>(
     }
 }
 
-/// Ensures index actions exist for every non-logic, non-virtual atom referenced by the
+/// Ensures index actions exist for every non-logic, non-view atom referenced by the
 /// loads. This prepares the relations to serve queries in the orders the plan needs.
 pub fn ensure_actions_for_loads<'a>(
     facts: &mut Relations,
@@ -213,8 +213,8 @@ pub fn ensure_actions_for_loads<'a>(
     for (load_atom, (action, _)) in loads.iter() {
         let name = body[*load_atom].name.as_str();
         let is_logic = crate::rules::atoms::logic::resolve(&body[*load_atom]).is_some();
-        let is_virtual = decls.get(name).map_or(false, |d| d.virt);
-        if !is_logic && !is_virtual {
+        let is_view = decls.get(name).map_or(false, |d| d.view);
+        if !is_logic && !is_view {
             facts.ensure_action(comms, name, action);
         }
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -31,9 +31,9 @@ pub use exec::ExecAtom;
 /// stable/recent split per the semi-naive convention. For virtual atoms, delegates
 /// to `Sum::build`.
 ///
-/// `parent_plan` is the surrounding rule's plan for this driver, threaded through so
+/// `parent_plan` is the surrounding rule's plan for this seed, threaded through so
 /// virtual atoms can compute their approach pattern from where they appear. `None`
-/// means the atom is itself the driver (no surrounding plan to inspect).
+/// means the atom is itself the seed (no surrounding plan to inspect).
 pub(crate) fn build_atom<'a>(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
@@ -64,17 +64,17 @@ pub(crate) fn build_atom<'a>(
     }
 }
 
-/// One plan stage's pre-built non-driver atoms, in plan order.
+/// One plan stage's pre-built non-seed atoms, in plan order.
 pub type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<&'a String> + 'a>>;
 
-/// One driver's pre-built apparatus: the driver atom (used for `seed`) and the
-/// per-stage non-driver atoms (used for `wco_join`).
-type DriverWork<'a> = (Box<dyn exec::ExecAtom<&'a String> + 'a>, Vec<StageBoxes<'a>>);
+/// One seed's pre-built apparatus: the seed atom (whose `.seed()` produces the initial
+/// salad) and the per-stage non-seed atoms (used for `wco_join`).
+type SeedWork<'a> = (Box<dyn exec::ExecAtom<&'a String> + 'a>, Vec<StageBoxes<'a>>);
 
-/// All drivers' apparatus, parallel to `Plans` iteration order.
-type DriverApparatus<'a> = Vec<DriverWork<'a>>;
+/// All seeds' apparatus, parallel to `Plans` iteration order.
+type SeedApparatus<'a> = Vec<SeedWork<'a>>;
 
-/// Plans a rule body and pre-builds the boxed atoms for every (driver, stage).
+/// Plans a rule body and pre-builds the boxed atoms for every (seed, stage).
 ///
 /// Lives as a free function (not a method) because virtual references recursively
 /// invoke this with the same field borrows. Callers split a `&mut State` into its
@@ -92,7 +92,7 @@ pub fn plan_and_build_with_fields<'a>(
 ) -> (
     plan::Plans<usize, &'a String>,
     plan::Loads<usize, &'a String>,
-    DriverApparatus<'a>,
+    SeedApparatus<'a>,
 ) {
     // Body atoms that should take a turn as the source of novelty this round.
     // In `stable` mode only the first body atom drives; in incremental mode every
@@ -106,17 +106,17 @@ pub fn plan_and_build_with_fields<'a>(
         (0..body.len()).collect()
     };
 
-    let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body, &delta_atoms, decls).expect("Unable to plan");
+    let (plans, loads) = plan::plan_rule(head, body, &delta_atoms, decls);
 
     // Ensure arranged facts exist for every load atom across every plan_atom.
     for (plan_atom, _plan) in plans.iter() {
         ensure_actions_for_loads(facts, comms, decls, body, &loads[plan_atom]);
     }
-    // Pre-build the driver atom and all non-driver stage atoms per planned driver.
-    // Pre-building all drivers (rather than building them inline during execution)
-    // means each driver sees the round's input state, not facts an earlier driver
+    // Pre-build the seed atom and all non-seed stage atoms per planned seed.
+    // Pre-building all seeds (rather than building them inline during execution)
+    // means each seed sees the round's input state, not facts an earlier seed
     // committed mid-loop — keeping semi-naive's "this round vs. next round" line clean.
-    let apparatus: DriverApparatus<'a> = plans.iter()
+    let apparatus: SeedApparatus<'a> = plans.iter()
         .map(|(plan_atom, plan)| {
             let plan_loads = &loads[plan_atom];
             let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
@@ -144,7 +144,7 @@ impl crate::types::State {
 
         // Split `self` into independent field borrows so that the apparatus (which holds
         // a borrow of `decls` and `rules` for as long as it lives) can coexist with
-        // mutations to `facts` and `comms` during per-driver execution and head emission.
+        // mutations to `facts` and `comms` during per-seed execution and head emission.
         let facts = &mut self.facts;
         let comms = &mut self.comms;
         let decls = &self.decls;
@@ -154,9 +154,9 @@ impl crate::types::State {
 
         let potato = ".potato".to_string();
 
-        // Per driver: seed → wco_join stages → emit head facts.
-        // Driver atoms are pre-built, so each driver sees the round's input state
-        // rather than facts that earlier drivers may have committed.
+        // Per seed: seed → wco_join stages → emit head facts.
+        // Seed atoms are pre-built, so each seed sees the round's input state
+        // rather than facts that earlier seeds may have committed.
         for ((_plan_atom, plan), (driver, stages_boxed)) in plans.iter().zip(apparatus) {
             let mut salad = driver.seed(comms, !stable);
             run_wco_stages(comms, &mut salad, plan, &stages_boxed, &potato);
@@ -223,6 +223,12 @@ pub fn ensure_actions_for_loads<'a>(
 /// The single shared loop pattern used by `State::implement`, `Sum::seed`, and
 /// `Sum::join_seeded`. Each stage's `(terms, atoms, order)` triple feeds one
 /// `wco_join` call; `potato` is the column-name placeholder for count metadata.
+///
+/// Stage 0 is special: its `terms` document the seed's pre-bound bindings (already
+/// present in `salad`), not new columns to introduce. We pass an empty `terms` set so
+/// `wco_join` semijoins against `init_atoms` instead of routing through
+/// `wco_join_inner` and trying to re-introduce already-bound columns. Stages 1+
+/// follow the usual interpretation of `terms` as the new columns to extend with.
 pub fn run_wco_stages<'a>(
     comms: &mut crate::comms::Comms,
     salad: &mut exec::Salad<&'a String>,
@@ -230,8 +236,9 @@ pub fn run_wco_stages<'a>(
     stages: &[StageBoxes<'a>],
     potato: &'a String,
 ) {
-    for ((_, terms, order), atoms) in plan.iter().zip(stages.iter()) {
-        exec::wco_join(comms, salad, terms, atoms, potato, &order[..]);
+    for (i, ((_, terms, order), atoms)) in plan.iter().zip(stages.iter()).enumerate() {
+        let stage_terms = if i == 0 { &Default::default() } else { terms };
+        exec::wco_join(comms, salad, stage_terms, atoms, potato, &order[..]);
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -28,11 +28,13 @@ pub use exec::ExecAtom;
 ///
 /// Dispatches between logic, virtual (sum), antijoin, and data variants based on the
 /// atom's name and the declarations. For data atoms, threads the appropriate
-/// stable/recent split per the semi-naive convention: atoms whose index exceeds the
-/// driver's contribute their `recent` facts, others contribute only `stable`. The
-/// driver itself contributes both. For virtual atoms, recursively plans and builds
-/// the defining rules' apparatus and constructs a `Sum`.
-fn build_atom<'a>(
+/// stable/recent split per the semi-naive convention. For virtual atoms, delegates
+/// to `Sum::build`.
+///
+/// `parent_plan` is the surrounding rule's plan for this driver, threaded through so
+/// virtual atoms can compute their approach pattern from where they appear. `None`
+/// means the atom is itself the driver (no surrounding plan to inspect).
+pub(crate) fn build_atom<'a>(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
@@ -41,29 +43,15 @@ fn build_atom<'a>(
     plan_atom: usize,
     load_atom: usize,
     loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
+    parent_plan: Option<&plan::Plan<usize, &'a String>>,
 ) -> Box<dyn exec::ExecAtom<&'a String> + 'a> {
     use crate::rules::atoms;
     if let Some(logic) = atoms::logic::resolve(&body[load_atom]) {
         Box::new(logic)
     } else if decls.get(body[load_atom].name.as_str()).map_or(false, |d| d.virt) {
-        // Virtual: pre-build apparatus per defining rule, construct a Sum.
-        let virt_name = body[load_atom].name.as_str();
-        let defining: Vec<&'a Rule> = rules.iter()
-            .map(|(r, _)| r)
-            .filter(|r| !r.head.is_empty() && r.head[0].name.as_str() == virt_name)
-            .collect();
-        let mut disjuncts: Vec<atoms::sum::Disjunct<'a>> = Vec::with_capacity(defining.len());
-        for rule in defining {
-            let (plans, loads, apparatus) = plan_and_build_with_fields(
-                facts, comms, decls, rules,
-                &rule.body[..], &rule.head[..],
-                true, None,
-            );
-            disjuncts.push(atoms::sum::Disjunct { rule, plans, loads, apparatus });
-        }
-        let use_site = &body[load_atom];
-        let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
-        Box::new(atoms::sum::Sum { use_site, head_terms, disjuncts })
+        Box::new(atoms::sum::Sum::build(
+            facts, comms, decls, rules, body, plan_atom, load_atom, parent_plan,
+        ))
     } else {
         let (load_action, load_terms) = &loads[&load_atom];
         let other = facts.get_action(body[load_atom].name.as_str(), load_action).unwrap();
@@ -77,7 +65,7 @@ fn build_atom<'a>(
 }
 
 /// One plan stage's pre-built non-driver atoms, in plan order.
-type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<&'a String> + 'a>>;
+pub type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<&'a String> + 'a>>;
 
 /// One driver's pre-built apparatus: the driver atom (used for `seed`) and the
 /// per-stage non-driver atoms (used for `wco_join`).
@@ -121,28 +109,20 @@ pub fn plan_and_build_with_fields<'a>(
     let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body, &delta_atoms, decls).expect("Unable to plan");
 
     // Ensure arranged facts exist for every load atom across every plan_atom.
-    // Skip logic and virtual atoms — neither has stored data to arrange.
     for (plan_atom, _plan) in plans.iter() {
-        let plan_loads = &loads[plan_atom];
-        for (load_atom, (action, _)) in plan_loads.iter() {
-            let name = body[*load_atom].name.as_str();
-            let is_logic = crate::rules::atoms::logic::resolve(&body[*load_atom]).is_some();
-            let is_virtual = decls.get(name).map_or(false, |d| d.virt);
-            if !is_logic && !is_virtual {
-                facts.ensure_action(comms, name, action);
-            }
-        }
+        ensure_actions_for_loads(facts, comms, decls, body, &loads[plan_atom]);
     }
     // Pre-build the driver atom and all non-driver stage atoms per planned driver.
-    // Pre-building drivers (in addition to non-drivers) means the apparatus is
-    // self-contained: callers can execute without any further trips into the state.
+    // Pre-building all drivers (rather than building them inline during execution)
+    // means each driver sees the round's input state, not facts an earlier driver
+    // committed mid-loop — keeping semi-naive's "this round vs. next round" line clean.
     let apparatus: DriverApparatus<'a> = plans.iter()
         .map(|(plan_atom, plan)| {
             let plan_loads = &loads[plan_atom];
-            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads);
+            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
             let stages: Vec<StageBoxes<'a>> = plan.iter()
                 .map(|(atoms, _, _)| atoms.iter()
-                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads))
+                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan)))
                     .collect::<Vec<_>>())
                 .collect();
             (driver, stages)
@@ -153,14 +133,6 @@ pub fn plan_and_build_with_fields<'a>(
 
 impl crate::types::State {
 
-    /// Plans a rule body and pre-builds the boxed non-driver atoms for every stage.
-    ///
-    /// Returns the planner's output (`plans`, `loads`) plus, in parallel with `plans`,
-    /// the boxed atoms for each stage of each driver. The caller drives execution per
-    /// driver against this apparatus (and may emit head facts, union into a sum, etc.).
-    ///
-    /// This is steps 1-4 of `implement`: choose drivers, plan, ensure index actions,
-    /// and build boxed atoms. Execution and head emission are the caller's concern.
     /// Implements a provided rule in the context of various facts.
     ///
     /// The `stable` argument indicates whether we should perform a join with all facts (true),
@@ -187,9 +159,7 @@ impl crate::types::State {
         // rather than facts that earlier drivers may have committed.
         for ((_plan_atom, plan), (driver, stages_boxed)) in plans.iter().zip(apparatus) {
             let mut salad = driver.seed(comms, !stable);
-            for ((_, terms, order), others) in plan.iter().zip(stages_boxed) {
-                exec::wco_join(comms, &mut salad, terms, &others[..], &potato, &order[..]);
-            }
+            run_wco_stages(comms, &mut salad, plan, &stages_boxed, &potato);
             emit_head_facts(facts, comms, head, salad);
         }
     }
@@ -226,6 +196,42 @@ fn emit_head_facts<'a>(
     }
     if let Some(pos) = exact_match {
         extend_facts_with_fields(facts, comms, &head[pos], salad.facts);
+    }
+}
+
+/// Ensures index actions exist for every non-logic, non-virtual atom referenced by the
+/// loads. This prepares the relations to serve queries in the orders the plan needs.
+pub fn ensure_actions_for_loads<'a>(
+    facts: &mut Relations,
+    comms: &mut crate::comms::Comms,
+    decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    body: &'a [Atom],
+    loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
+) {
+    for (load_atom, (action, _)) in loads.iter() {
+        let name = body[*load_atom].name.as_str();
+        let is_logic = crate::rules::atoms::logic::resolve(&body[*load_atom]).is_some();
+        let is_virtual = decls.get(name).map_or(false, |d| d.virt);
+        if !is_logic && !is_virtual {
+            facts.ensure_action(comms, name, action);
+        }
+    }
+}
+
+/// Runs the wco_join stages of a plan against a salad, mutating the salad in place.
+///
+/// The single shared loop pattern used by `State::implement`, `Sum::seed`, and
+/// `Sum::join_seeded`. Each stage's `(terms, atoms, order)` triple feeds one
+/// `wco_join` call; `potato` is the column-name placeholder for count metadata.
+pub fn run_wco_stages<'a>(
+    comms: &mut crate::comms::Comms,
+    salad: &mut exec::Salad<&'a String>,
+    plan: &plan::Plan<usize, &'a String>,
+    stages: &[StageBoxes<'a>],
+    potato: &'a String,
+) {
+    for ((_, terms, order), atoms) in plan.iter().zip(stages.iter()) {
+        exec::wco_join(comms, salad, terms, atoms, potato, &order[..]);
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -53,17 +53,33 @@ fn build_atom<'a>(
     }
 }
 
+/// One plan stage's pre-built non-driver atoms, in plan order.
+type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<&'a String> + 'a>>;
+
+/// All driver-keyed plans' boxed stages, parallel to `Plans`.
+type DriverStages<'a> = Vec<Vec<StageBoxes<'a>>>;
+
 impl crate::types::State {
 
-    /// Implements a provided rule in the context of various facts.
+    /// Plans a rule body and pre-builds the boxed non-driver atoms for every stage.
     ///
-    /// The `stable` argument indicates whether we should perform a join with all facts (true),
-    /// or only a join that involves novel facts (false).
-    pub fn implement(&mut self, rule: &Rule, stable: bool, active_relations: Option<&std::collections::BTreeSet<&str>>) {
-
-        let head = &rule.head[..];
-        let body = &rule.body[..];
-
+    /// Returns the planner's output (`plans`, `loads`) plus, in parallel with `plans`,
+    /// the boxed atoms for each stage of each driver. The caller drives execution per
+    /// driver against this apparatus (and may emit head facts, union into a sum, etc.).
+    ///
+    /// This is steps 1-4 of `implement`: choose drivers, plan, ensure index actions,
+    /// and build boxed atoms. Execution and head emission are the caller's concern.
+    pub fn plan_and_build<'a>(
+        &mut self,
+        body: &'a [Atom],
+        head: &'a [Atom],
+        stable: bool,
+        active_relations: Option<&std::collections::BTreeSet<&str>>,
+    ) -> (
+        plan::Plans<usize, &'a String>,
+        plan::Loads<usize, &'a String>,
+        DriverStages<'a>,
+    ) {
         // Body atoms that should take a turn as the source of novelty this round.
         // In `stable` mode only the first body atom drives; in incremental mode every
         // atom takes a turn, optionally restricted to those whose relation has recent
@@ -78,11 +94,7 @@ impl crate::types::State {
 
         let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body, &delta_atoms).expect("Unable to plan");
 
-        let potato = ".potato".to_string();
-
-        //  Build phase.
-        //      1. Ensure arranged facts exist for every load atom across every plan_atom.
-        //      2. Pre-build all boxed atoms for every (plan_atom, stage).
+        // Ensure arranged facts exist for every load atom across every plan_atom.
         for (plan_atom, _plan) in plans.iter() {
             let plan_loads = &loads[plan_atom];
             for (load_atom, (action, _)) in plan_loads.iter() {
@@ -91,7 +103,8 @@ impl crate::types::State {
                 }
             }
         }
-        let all_stages_boxed: Vec<_> = plans.iter()
+        // Pre-build all boxed atoms for every (plan_atom, stage).
+        let all_stages_boxed: DriverStages<'a> = plans.iter()
             .map(|(plan_atom, plan)| {
                 let plan_loads = &loads[plan_atom];
                 plan.iter()
@@ -101,12 +114,23 @@ impl crate::types::State {
                     .collect::<Vec<_>>()
             })
             .collect();
+        (plans, loads, all_stages_boxed)
+    }
 
-        //  Execute phase. Each planned delta atom
-        //      1. loads its facts, then
-        //      2. repeatedly joins in new terms, then
-        //      3. commits derived facts to the stores for head atoms.
+    /// Implements a provided rule in the context of various facts.
+    ///
+    /// The `stable` argument indicates whether we should perform a join with all facts (true),
+    /// or only a join that involves novel facts (false).
+    pub fn implement(&mut self, rule: &Rule, stable: bool, active_relations: Option<&std::collections::BTreeSet<&str>>) {
 
+        let head = &rule.head[..];
+        let body = &rule.body[..];
+
+        let (plans, loads, all_stages_boxed) = self.plan_and_build(body, head, stable, active_relations);
+
+        let potato = ".potato".to_string();
+
+        // Per driver: seed → wco_join stages → emit head facts.
         for ((plan_atom, plan), stages_boxed) in plans.iter().zip(all_stages_boxed) {
             let plan_atom = *plan_atom;
             let plan_loads = &loads[&plan_atom];
@@ -120,7 +144,7 @@ impl crate::types::State {
                 exec::wco_join(&mut self.comms, &mut salad, terms, &others[..], &potato, &order[..]);
             }
 
-            // Stage 3: Commit produced facts back to head atoms in `self.facts`.
+            // Step 3: Commit produced facts back to head atoms in `self.facts`.
             self.emit_head_facts(head, salad);
         }
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -44,9 +44,10 @@ pub(crate) fn build_atom<'a>(
     load_atom: usize,
     loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
     parent_plan: Option<&plan::Plan<usize, &'a String>>,
+    subst: &plan::Subst<'a>,
 ) -> Box<dyn exec::ExecAtom<&'a String> + 'a> {
     use crate::rules::atoms;
-    if let Some(logic) = atoms::logic::resolve(&body[load_atom]) {
+    if let Some(logic) = atoms::logic::resolve_with_subst(&body[load_atom], subst) {
         Box::new(logic)
     } else if decls.get(body[load_atom].name.as_str()).map_or(false, |d| d.virt) {
         Box::new(atoms::sum::Sum::build(
@@ -119,10 +120,11 @@ pub fn plan_and_build_with_fields<'a>(
     let apparatus: SeedApparatus<'a> = plans.iter()
         .map(|(plan_atom, plan)| {
             let plan_loads = &loads[plan_atom];
-            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
+            let empty_subst = plan::Subst::new();
+            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None, &empty_subst);
             let stages: Vec<StageBoxes<'a>> = plan.iter()
                 .map(|(atoms, _, _)| atoms.iter()
-                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan)))
+                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan), &empty_subst))
                     .collect::<Vec<_>>())
                 .collect();
             (driver, stages)

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -26,21 +26,44 @@ pub use exec::ExecAtom;
 
 /// Constructs a boxed `ExecAtom` for an atom in a rule body.
 ///
-/// Selects between logic, antijoin, and data variants based on the atom's
-/// properties, and threads the appropriate stable/recent split per the
-/// semi-naive convention: atoms whose index exceeds the driver's contribute
-/// their `recent` facts, others contribute only `stable`.
-/// The driver itself contributes both `recent` and `stable` facts.
+/// Dispatches between logic, virtual (sum), antijoin, and data variants based on the
+/// atom's name and the declarations. For data atoms, threads the appropriate
+/// stable/recent split per the semi-naive convention: atoms whose index exceeds the
+/// driver's contribute their `recent` facts, others contribute only `stable`. The
+/// driver itself contributes both. For virtual atoms, recursively plans and builds
+/// the defining rules' apparatus and constructs a `Sum`.
 fn build_atom<'a>(
+    facts: &mut Relations,
+    comms: &mut crate::comms::Comms,
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    rules: &'a [(Rule, Vec<std::time::Duration>)],
     body: &'a [Atom],
     plan_atom: usize,
     load_atom: usize,
     loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
-    facts: &Relations,
 ) -> Box<dyn exec::ExecAtom<&'a String> + 'a> {
     use crate::rules::atoms;
     if let Some(logic) = atoms::logic::resolve(&body[load_atom]) {
         Box::new(logic)
+    } else if decls.get(body[load_atom].name.as_str()).map_or(false, |d| d.virt) {
+        // Virtual: pre-build apparatus per defining rule, construct a Sum.
+        let virt_name = body[load_atom].name.as_str();
+        let defining: Vec<&'a Rule> = rules.iter()
+            .map(|(r, _)| r)
+            .filter(|r| !r.head.is_empty() && r.head[0].name.as_str() == virt_name)
+            .collect();
+        let mut disjuncts: Vec<atoms::sum::Disjunct<'a>> = Vec::with_capacity(defining.len());
+        for rule in defining {
+            let (plans, loads, apparatus) = plan_and_build_with_fields(
+                facts, comms, decls, rules,
+                &rule.body[..], &rule.head[..],
+                true, None,
+            );
+            disjuncts.push(atoms::sum::Disjunct { rule, plans, loads, apparatus });
+        }
+        let use_site = &body[load_atom];
+        let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
+        Box::new(atoms::sum::Sum { use_site, head_terms, disjuncts })
     } else {
         let (load_action, load_terms) = &loads[&load_atom];
         let other = facts.get_action(body[load_atom].name.as_str(), load_action).unwrap();
@@ -56,8 +79,77 @@ fn build_atom<'a>(
 /// One plan stage's pre-built non-driver atoms, in plan order.
 type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<&'a String> + 'a>>;
 
-/// All driver-keyed plans' boxed stages, parallel to `Plans`.
-type DriverStages<'a> = Vec<Vec<StageBoxes<'a>>>;
+/// One driver's pre-built apparatus: the driver atom (used for `seed`) and the
+/// per-stage non-driver atoms (used for `wco_join`).
+type DriverWork<'a> = (Box<dyn exec::ExecAtom<&'a String> + 'a>, Vec<StageBoxes<'a>>);
+
+/// All drivers' apparatus, parallel to `Plans` iteration order.
+type DriverApparatus<'a> = Vec<DriverWork<'a>>;
+
+/// Plans a rule body and pre-builds the boxed atoms for every (driver, stage).
+///
+/// Lives as a free function (not a method) because virtual references recursively
+/// invoke this with the same field borrows. Callers split a `&mut State` into its
+/// fields and pass them through. `rules` is the State's rule list, used to look up
+/// virtual relations' defining rules during sum-atom construction.
+pub fn plan_and_build_with_fields<'a>(
+    facts: &mut Relations,
+    comms: &mut crate::comms::Comms,
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    rules: &'a [(Rule, Vec<std::time::Duration>)],
+    body: &'a [Atom],
+    head: &'a [Atom],
+    stable: bool,
+    active_relations: Option<&std::collections::BTreeSet<&str>>,
+) -> (
+    plan::Plans<usize, &'a String>,
+    plan::Loads<usize, &'a String>,
+    DriverApparatus<'a>,
+) {
+    // Body atoms that should take a turn as the source of novelty this round.
+    // In `stable` mode only the first body atom drives; in incremental mode every
+    // atom takes a turn, optionally restricted to those whose relation has recent
+    // facts on some worker.
+    let delta_atoms: Vec<usize> = if stable {
+        vec![0]
+    } else if let Some(active) = active_relations {
+        (0..body.len()).filter(|i| active.contains(body[*i].name.as_str())).collect()
+    } else {
+        (0..body.len()).collect()
+    };
+
+    let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body, &delta_atoms, decls).expect("Unable to plan");
+
+    // Ensure arranged facts exist for every load atom across every plan_atom.
+    // Skip logic and virtual atoms — neither has stored data to arrange.
+    for (plan_atom, _plan) in plans.iter() {
+        let plan_loads = &loads[plan_atom];
+        for (load_atom, (action, _)) in plan_loads.iter() {
+            let name = body[*load_atom].name.as_str();
+            let is_logic = crate::rules::atoms::logic::resolve(&body[*load_atom]).is_some();
+            let is_virtual = decls.get(name).map_or(false, |d| d.virt);
+            if !is_logic && !is_virtual {
+                facts.ensure_action(comms, name, action);
+            }
+        }
+    }
+    // Pre-build the driver atom and all non-driver stage atoms per planned driver.
+    // Pre-building drivers (in addition to non-drivers) means the apparatus is
+    // self-contained: callers can execute without any further trips into the state.
+    let apparatus: DriverApparatus<'a> = plans.iter()
+        .map(|(plan_atom, plan)| {
+            let plan_loads = &loads[plan_atom];
+            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads);
+            let stages: Vec<StageBoxes<'a>> = plan.iter()
+                .map(|(atoms, _, _)| atoms.iter()
+                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads))
+                    .collect::<Vec<_>>())
+                .collect();
+            (driver, stages)
+        })
+        .collect();
+    (plans, loads, apparatus)
+}
 
 impl crate::types::State {
 
@@ -69,54 +161,6 @@ impl crate::types::State {
     ///
     /// This is steps 1-4 of `implement`: choose drivers, plan, ensure index actions,
     /// and build boxed atoms. Execution and head emission are the caller's concern.
-    pub fn plan_and_build<'a>(
-        &mut self,
-        body: &'a [Atom],
-        head: &'a [Atom],
-        stable: bool,
-        active_relations: Option<&std::collections::BTreeSet<&str>>,
-    ) -> (
-        plan::Plans<usize, &'a String>,
-        plan::Loads<usize, &'a String>,
-        DriverStages<'a>,
-    ) {
-        // Body atoms that should take a turn as the source of novelty this round.
-        // In `stable` mode only the first body atom drives; in incremental mode every
-        // atom takes a turn, optionally restricted to those whose relation has recent
-        // facts on some worker.
-        let delta_atoms: Vec<usize> = if stable {
-            vec![0]
-        } else if let Some(active) = active_relations {
-            (0..body.len()).filter(|i| active.contains(body[*i].name.as_str())).collect()
-        } else {
-            (0..body.len()).collect()
-        };
-
-        let (plans, loads) = plan::plan_rule::<plan::ByTerm>(head, body, &delta_atoms).expect("Unable to plan");
-
-        // Ensure arranged facts exist for every load atom across every plan_atom.
-        for (plan_atom, _plan) in plans.iter() {
-            let plan_loads = &loads[plan_atom];
-            for (load_atom, (action, _)) in plan_loads.iter() {
-                if crate::rules::atoms::logic::resolve(&body[*load_atom]).is_none() {
-                    self.facts.ensure_action(&mut self.comms, body[*load_atom].name.as_str(), action);
-                }
-            }
-        }
-        // Pre-build all boxed atoms for every (plan_atom, stage).
-        let all_stages_boxed: DriverStages<'a> = plans.iter()
-            .map(|(plan_atom, plan)| {
-                let plan_loads = &loads[plan_atom];
-                plan.iter()
-                    .map(|(atoms, _, _)| atoms.iter()
-                        .map(|load_atom| build_atom(body, *plan_atom, *load_atom, plan_loads, &self.facts))
-                        .collect::<Vec<_>>())
-                    .collect::<Vec<_>>()
-            })
-            .collect();
-        (plans, loads, all_stages_boxed)
-    }
-
     /// Implements a provided rule in the context of various facts.
     ///
     /// The `stable` argument indicates whether we should perform a join with all facts (true),
@@ -126,60 +170,74 @@ impl crate::types::State {
         let head = &rule.head[..];
         let body = &rule.body[..];
 
-        let (plans, loads, all_stages_boxed) = self.plan_and_build(body, head, stable, active_relations);
+        // Split `self` into independent field borrows so that the apparatus (which holds
+        // a borrow of `decls` and `rules` for as long as it lives) can coexist with
+        // mutations to `facts` and `comms` during per-driver execution and head emission.
+        let facts = &mut self.facts;
+        let comms = &mut self.comms;
+        let decls = &self.decls;
+        let rules = &self.rules[..];
+
+        let (plans, _loads, apparatus) = plan_and_build_with_fields(facts, comms, decls, rules, body, head, stable, active_relations);
 
         let potato = ".potato".to_string();
 
         // Per driver: seed → wco_join stages → emit head facts.
-        for ((plan_atom, plan), stages_boxed) in plans.iter().zip(all_stages_boxed) {
-            let plan_atom = *plan_atom;
-            let plan_loads = &loads[&plan_atom];
-
-            // Step 1: Load the initial facts to seed the sequence of joins.
-            let root = build_atom(body, plan_atom, plan_atom, plan_loads, &self.facts);
-            let mut salad = root.seed(&mut self.comms, !stable);
-
-            // Step 2: Repeatedly join in sets of terms through sets of atoms.
+        // Driver atoms are pre-built, so each driver sees the round's input state
+        // rather than facts that earlier drivers may have committed.
+        for ((_plan_atom, plan), (driver, stages_boxed)) in plans.iter().zip(apparatus) {
+            let mut salad = driver.seed(comms, !stable);
             for ((_, terms, order), others) in plan.iter().zip(stages_boxed) {
-                exec::wco_join(&mut self.comms, &mut salad, terms, &others[..], &potato, &order[..]);
+                exec::wco_join(comms, &mut salad, terms, &others[..], &potato, &order[..]);
             }
-
-            // Step 3: Commit produced facts back to head atoms in `self.facts`.
-            self.emit_head_facts(head, salad);
+            emit_head_facts(facts, comms, head, salad);
         }
     }
+}
 
-    /// Projects `salad` through each head atom and extends the corresponding relation.
-    ///
-    /// If a head atom's term order matches `salad` exactly, its facts are committed
-    /// without re-projection; otherwise, an `Action` is built for the head and applied.
-    fn emit_head_facts(&mut self, head: &[Atom], mut salad: crate::rules::exec::Salad<&String>) {
+/// Projects `salad` through each head atom and extends the corresponding relation.
+///
+/// Free function so it can coexist with an outstanding apparatus borrow on `decls`.
+fn emit_head_facts<'a>(
+    facts: &mut Relations,
+    comms: &mut crate::comms::Comms,
+    head: &[Atom],
+    mut salad: crate::rules::exec::Salad<&'a String>,
+) {
+    let exact_match = head.iter().position(|a| {
+        a.terms.len() == salad.arity() &&
+        a.terms.iter().zip(salad.terms.iter()).all(|(h,d)| h.as_var() == Some(d))
+    });
 
-        // It is possible that with a single head we have the terms in the right order,
-        // and can simply commit `delta`. There could be multiple heads, and the action
-        // could be not the identity.
-        let exact_match = head.iter().position(|a| {
-            a.terms.len() == salad.arity() &&
-            a.terms.iter().zip(salad.terms.iter()).all(|(h,d)| h.as_var() == Some(d))
-        });
-
-        let thresh = 200_000_000 / self.comms.peers();
-        for (_, atom) in head.iter().enumerate().filter(|(pos,_)| Some(*pos) != exact_match) {
-            let mut action = Action::with_arity(salad.arity());
-            action.projection = atom.terms.iter().map(|t| match t {
-                Term::Var(name) => Ok(salad.terms.iter().position(|t2| t2 == &name).expect(format!("Failed to find {:?} in {:?}", name, salad.terms).as_str())),
-                Term::Lit(data) => Err(data.clone()),
-            }).collect();
-            if let Some(delta) = salad.facts.flatten() {
-                self.extend_facts(atom, delta.act_on(&action, thresh));
-                salad.extend([delta]);
-            }
-            else {
-                self.extend_facts(atom, Default::default());
-            }
+    let thresh = 200_000_000 / comms.peers();
+    for (_, atom) in head.iter().enumerate().filter(|(pos,_)| Some(*pos) != exact_match) {
+        let mut action = Action::with_arity(salad.arity());
+        action.projection = atom.terms.iter().map(|t| match t {
+            Term::Var(name) => Ok(salad.terms.iter().position(|t2| t2 == &name).expect(format!("Failed to find {:?} in {:?}", name, salad.terms).as_str())),
+            Term::Lit(data) => Err(data.clone()),
+        }).collect();
+        if let Some(delta) = salad.facts.flatten() {
+            extend_facts_with_fields(facts, comms, atom, delta.act_on(&action, thresh));
+            salad.extend([delta]);
         }
-        if let Some(pos) = exact_match {
-            self.extend_facts(&head[pos], salad.facts);
+        else {
+            extend_facts_with_fields(facts, comms, atom, Default::default());
         }
+    }
+    if let Some(pos) = exact_match {
+        extend_facts_with_fields(facts, comms, &head[pos], salad.facts);
+    }
+}
+
+/// Free-function form of `State::extend_facts` so it can be called with split borrows.
+pub fn extend_facts_with_fields(
+    facts: &mut Relations,
+    comms: &mut crate::comms::Comms,
+    atom: &Atom,
+    mut data: crate::facts::FactLSM<Forest<Terms>>,
+) {
+    comms.exchange(&mut data);
+    if let Some(columns) = data.flatten() {
+        facts.entry(atom).extend([columns]);
     }
 }

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -45,7 +45,12 @@ pub type Loads<A, T> = BTreeMap<A, BTreeMap<A, Load<T>>>;
 /// novelty (the semi-naive delta). The returned plans map contains an entry for each
 /// requested delta atom that the strategy can plan (logic atoms that can't ground all
 /// their terms are silently dropped, regardless of the request).
-pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(head: &'a [Atom], body: &'a [Atom], delta_atoms: &[usize]) -> Result<(Plans<usize, &'a String>, Loads<usize, &'a String>), String> {
+pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(
+    head: &'a [Atom],
+    body: &'a [Atom],
+    delta_atoms: &[usize],
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+) -> Result<(Plans<usize, &'a String>, Loads<usize, &'a String>), String> {
 
     // We'll pick a target term order for the first head; other heads may require transforms.
     // If we have multiple heads and one has no literals or repetitions, that would be best.
@@ -56,6 +61,9 @@ pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(head: &'a [Atom], body: &'a
         let terms = atom.terms.iter().filter_map(|term| term.as_var()).collect::<BTreeSet<_>>();
         let boxed_atom: Box<dyn PlanAtom<&'a String>+'a> =
         if let Some(logic) = crate::rules::atoms::logic::resolve(atom) { Box::new(logic) }
+        else if decls.get(atom.name.as_str()).map_or(false, |d| d.virt) {
+            Box::new(crate::rules::atoms::sum::SumPlan { head_terms: terms })
+        }
         else if !atom.anti { Box::new(terms) }
         else { Box::new(crate::rules::atoms::anti::Anti(terms)) };
         (index, boxed_atom)

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -45,6 +45,39 @@ pub type Loads<A, T> = BTreeMap<A, BTreeMap<A, Load<T>>>;
 /// novelty (the semi-naive delta). The returned plans map contains an entry for each
 /// requested delta atom that the strategy can plan (logic atoms that can't ground all
 /// their terms are silently dropped, regardless of the request).
+/// Builds the per-body-atom `PlanAtom` map that both `plan_rule` and `plan_rule_seeded`
+/// feed to the strategy. Dispatches on logic, virtual, anti, or data-relation atom kind.
+fn build_atoms_map<'a>(
+    body: &'a [Atom],
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+) -> BTreeMap<usize, Box<dyn PlanAtom<&'a String> + 'a>> {
+    body.iter().enumerate().map(|(index, atom)| {
+        let terms = atom.terms.iter().filter_map(|term| term.as_var()).collect::<BTreeSet<_>>();
+        let boxed_atom: Box<dyn PlanAtom<&'a String>+'a> =
+        if let Some(logic) = crate::rules::atoms::logic::resolve(atom) { Box::new(logic) }
+        else if decls.get(atom.name.as_str()).map_or(false, |d| d.virt) {
+            Box::new(crate::rules::atoms::sum::SumPlan { head_terms: terms })
+        }
+        else if !atom.anti { Box::new(terms) }
+        else { Box::new(crate::rules::atoms::anti::Anti(terms)) };
+        (index, boxed_atom)
+    }).collect()
+}
+
+/// Removes the driver from its own stage-0 atom set and clears stage 0's terms.
+/// The driver is already loaded as the seed salad; stage 0's atoms and terms in the
+/// raw plan are an artifact of the planner's projection logic.
+///
+/// Must run *after* the projection-target computation in `plan_rule`: that logic
+/// uses stage 0's `init_terms` to size the projection action, so we can't clear
+/// them until that work is done.
+fn tidy_stage_zero<'a>(plan: &mut Plan<usize, &'a String>, driver: &usize) {
+    if let Some((atoms, terms, _)) = plan.first_mut() {
+        atoms.remove(driver);
+        terms.clear();
+    }
+}
+
 pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(
     head: &'a [Atom],
     body: &'a [Atom],
@@ -56,18 +89,7 @@ pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(
     // If we have multiple heads and one has no literals or repetitions, that would be best.
     let head_terms = head_order(head);
 
-    // Map from atom identifier to boxed `PlanAtom`, containing term and grounding information.
-    let atoms = body.iter().enumerate().map(|(index, atom)| {
-        let terms = atom.terms.iter().filter_map(|term| term.as_var()).collect::<BTreeSet<_>>();
-        let boxed_atom: Box<dyn PlanAtom<&'a String>+'a> =
-        if let Some(logic) = crate::rules::atoms::logic::resolve(atom) { Box::new(logic) }
-        else if decls.get(atom.name.as_str()).map_or(false, |d| d.virt) {
-            Box::new(crate::rules::atoms::sum::SumPlan { head_terms: terms })
-        }
-        else if !atom.anti { Box::new(terms) }
-        else { Box::new(crate::rules::atoms::anti::Anti(terms)) };
-        (index, boxed_atom)
-    }).collect::<BTreeMap<_,_>>();
+    let atoms = build_atoms_map(body, decls);
 
     // We'll want to pre-plan the term orders for each atom update rule, so that we can
     // pre-ensure that the necessary input shapes exist, with each atom in term order.
@@ -127,16 +149,9 @@ pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(
         }
     }
 
-    // Tidy stage 0 for the executor: drop the driver from its own stage 0 atoms (it is
-    // already loaded as the salad), and clear stage 0's terms (they are present in the
-    // salad from the driver load, not introduced by stage 0's atom-side operations).
-    // Both transformations are post-hoc — the planner's projection logic above relies
-    // on stage 0's terms holding `init_terms`, so we wait until that work is done.
+    // Tidy stage 0 for the executor — defer until after the projection logic above.
     for (plan_atom, plan) in plans.iter_mut() {
-        if let Some((atoms, terms, _)) = plan.first_mut() {
-            atoms.remove(plan_atom);
-            terms.clear();
-        }
+        tidy_stage_zero(plan, plan_atom);
     }
 
     Ok((plans, load_actions))
@@ -191,6 +206,61 @@ pub fn load_actions<A: Ord + Copy, T: Ord + Copy>(
 fn head_order<'a>(head: &'a [Atom]) -> Vec<&'a String> {
     let mut seen: BTreeSet<&'a String> = BTreeSet::default();
     head.iter().flat_map(|a| a.terms.iter()).filter_map(|t| t.as_var()).filter(|t| seen.insert(t)).collect()
+}
+
+/// A `PlanAtom` representing a synthetic driver whose terms are pre-bound from outside.
+///
+/// `terms()` returns the pre-bound set; `ground()` returns it for any input (the
+/// phantom can always provide its terms — they came from the caller's salad).
+struct Phantom<T> {
+    terms: BTreeSet<T>,
+}
+
+impl<T: Ord + Copy> PlanAtom<T> for Phantom<T> {
+    fn terms(&self) -> BTreeSet<T> { self.terms.clone() }
+    fn ground(&self, _: &BTreeSet<T>) -> BTreeSet<T> { self.terms.clone() }
+}
+
+/// Plans a rule body with a phantom driver representing pre-bound terms.
+///
+/// Returns a single `Plan` and the corresponding loads, both indexed by body atom
+/// position (the phantom uses index `body.len()` and is invisible to the caller).
+/// The plan is keyed for the phantom driver — execution should seed from the
+/// caller-provided salad rather than from any body atom.
+pub fn plan_rule_seeded<'a, S: Strategy<usize, &'a String>>(
+    head: &'a [Atom],
+    body: &'a [Atom],
+    pre_bound: BTreeSet<&'a String>,
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+) -> Result<(Plan<usize, &'a String>, BTreeMap<usize, Load<&'a String>>), String> {
+
+    let head_terms = head_order(head);
+    let mut atoms = build_atoms_map(body, decls);
+
+    // Insert the phantom driver at `body.len()` and use it as the sole delta atom.
+    let phantom_idx = body.len();
+    atoms.insert(phantom_idx, Box::new(Phantom { terms: pre_bound }));
+
+    let mut plans = S::plan_rule(&atoms, &[phantom_idx], &head_terms);
+    let mut plan = plans.remove(&phantom_idx).ok_or_else(|| "seeded plan failed".to_string())?;
+
+    // Compute base actions (only for body atoms; phantom isn't a real atom).
+    let base_actions = body.iter().enumerate().map(|(index, atom)| {
+        let mut action = Action::from_body(atom);
+        action.projection.sort_by_key(|p| atom.terms[*p.as_ref().unwrap()].as_var().unwrap());
+        (index, action)
+    }).collect::<BTreeMap<_,_>>();
+
+    // Compute load actions for the single phantom-driven plan.
+    let atoms_to_terms = atoms.iter().map(|(index, boxed)| (*index, boxed.terms())).collect::<BTreeMap<_,_>>();
+    let single_plan_map: BTreeMap<usize, Plan<usize, &'a String>> =
+        std::iter::once((phantom_idx, plan.clone())).collect();
+    let mut all_loads = load_actions(&single_plan_map, &atoms_to_terms, &base_actions);
+    let loads = all_loads.remove(&phantom_idx).unwrap_or_default();
+
+    tidy_stage_zero(&mut plan, &phantom_idx);
+
+    Ok((plan, loads))
 }
 
 /// A type that can produce an update plan for a rule.

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -79,15 +79,20 @@ pub trait PlanAtom<T: Ord> {
 use std::collections::{BTreeSet, BTreeMap};
 use crate::types::{Atom, Action};
 
-/// A plan is a sequence of sets of atoms and terms, and an output term order.
+/// A plan is a sequence of stages, each a tuple of (atoms, terms, output order).
 ///
-/// Each plan stage uses the atoms to express their thoughts about the terms,
-/// each either joining or semijoining, depending on which terms are present.
-/// The term sets are disjoint, as each term can be *introduced* at most once,
-/// but the atom sets may repeat atoms as their many terms are introduced.
+/// Each stage indicates terms that are added, and the atoms that participate in the
+/// introduction of those terms. Each atom name restricts the solution space by their
+/// projection onto all terms added through this stage. Each term is added only once.
 ///
-/// The output term order discards columns that are no longer needed, and in
-/// the last plan stage ensures that the order matches that of the rule head.
+/// The output term order indicates the terms that survive the stage, and a preference
+/// for their order that may be beneficial for the next stage. Terms not present in the
+/// output order should be pruned.
+///
+/// The first stage is special, in that its terms are specified exogenously by a "seed"
+/// relation that starts the sequence of joins. The atoms of the first stage intersect
+/// these terms, but they may not fully span it, and it should not be distressing that
+/// the plan cannot independently substantiate those terms.
 pub type Plan<A, T> = Vec<(BTreeSet<A>, BTreeSet<T>, Vec<T>)>;
 pub type Plans<A, T> = BTreeMap<A, Plan<A, T>>;
 pub type Load<T> = (Action<Vec<u8>>, Vec<T>);
@@ -171,7 +176,7 @@ fn seed_load<'a>(
 ///
 /// For each body atom, loads the atom's terms in the order the plan binds them.
 /// This order aims to minimize the number of distinct term orders to maintain.
-pub fn body_load<'a, A: Ord + Copy, T: Ord + Copy>(
+fn body_load<'a, A: Ord + Copy, T: Ord + Copy>(
     plan: &Plan<A, T>,
     body: &BTreeMap<A, Box<dyn PlanAtom<T> + 'a>>,
     base_actions: &BTreeMap<A, Action<Vec<u8>>>,

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -77,7 +77,21 @@ pub trait PlanAtom<T: Ord> {
 }
 
 use std::collections::{BTreeSet, BTreeMap};
-use crate::types::{Atom, Action};
+use crate::types::{Atom, Action, Term};
+
+/// Substitution map: body var name → its replacement under composition.
+///
+/// Each entry rewrites a body var to either another var (`Term::Var` — rename, often
+/// to a use-site var name to unify head and use-site spaces) or a literal
+/// (`Term::Lit` — constant pushdown, baked into atom load actions as `lit_filter`).
+/// Values are `&'a Term` borrowed from the use-site atom; refs have `'a` lifetime so
+/// `PlanAtom` term sets and load actions can use the inner `&'a String`/`&'a Vec<u8>`
+/// directly without allocation.
+///
+/// Used by the view planner to fold use-site constraints into the body's atom views
+/// without allocating new `Atom` structs. `build_atoms_map` and `base_actions_for`
+/// consult this when computing per-atom term sets and load actions.
+pub type Subst<'a> = BTreeMap<&'a String, &'a Term>;
 
 /// A plan is a sequence of stages, each a tuple of (atoms, terms, output order).
 ///
@@ -112,8 +126,9 @@ pub fn plan_rule<'a>(
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
 ) -> (Plans<usize, &'a String>, Loads<usize, &'a String>) {
 
-    let head_terms = head_order(head);
-    let base_actions = base_actions_for(body);
+    let empty_subst: Subst<'a> = BTreeMap::new();
+    let head_terms = head_order(head, &empty_subst);
+    let base_actions = base_actions_for(body, &empty_subst);
 
     let mut plans: Plans<usize, &'a String> = BTreeMap::default();
     let mut loads: Loads<usize, &'a String> = BTreeMap::default();
@@ -121,7 +136,7 @@ pub fn plan_rule<'a>(
     // One atoms map; each iteration takes a seed_idx out as the seed and puts it back
     // at the end. Same round-robin shape as semi-naive: the body's atoms are stable;
     // which one supplies the novelty rotates.
-    let mut atoms = build_atoms_map(body, decls);
+    let mut atoms = build_atoms_map(body, &empty_subst, decls);
     for &seed_idx in seed_atoms {
         if let Some(seed_atom) = atoms.remove(&seed_idx) {
             if seed_atom.terms() == seed_atom.ground(&Default::default()) {
@@ -204,11 +219,23 @@ fn body_load<'a, A: Ord + Copy, T: Ord + Copy>(
 
 /// Produces a term order for head atoms.
 ///
-/// The order is of distinct terms in order of presentation.
-/// Repeated terms and literals should be added in post.
-fn head_order<'a>(head: &'a [Atom]) -> Vec<&'a String> {
+/// The order is of distinct terms in order of presentation, with `subst` applied
+/// (Var→Var renames are reflected; Var→Lit substitutions drop out, as do raw lits).
+/// Pass empty `Subst` for the non-virtual path.
+fn head_order<'a>(head: &'a [Atom], subst: &Subst<'a>) -> Vec<&'a String> {
     let mut seen: BTreeSet<&'a String> = BTreeSet::default();
-    head.iter().flat_map(|a| a.terms.iter()).filter_map(|t| t.as_var()).filter(|t| seen.insert(t)).collect()
+    head.iter()
+        .flat_map(|a| a.terms.iter())
+        .filter_map(|t| match t {
+            Term::Var(name) => match subst.get(name) {
+                Some(Term::Var(new_name)) => Some(new_name),
+                Some(Term::Lit(_)) => None,
+                None => Some(name),
+            },
+            Term::Lit(_) => None,
+        })
+        .filter(|t| seen.insert(t))
+        .collect()
 }
 
 /// Plans a single-head rule body around a caller-provided seed of pre-bound terms.
@@ -218,15 +245,15 @@ fn head_order<'a>(head: &'a [Atom]) -> Vec<&'a String> {
 /// salad and wants stages that introduce the rest of the body's variables. The single
 /// head atom matches the disjunct shape — multi-head rules don't arise on this path.
 pub fn plan_rule_seeded<'a>(
-    head: &'a Atom,
     body: &'a [Atom],
     seed: &[&'a String],
+    need: &[&'a String],
+    subst: &Subst<'a>,
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
 ) -> (Plan<usize, &'a String>, BTreeMap<usize, Load<&'a String>>) {
-    let head_terms = head_order(std::slice::from_ref(head));
-    let atoms = build_atoms_map(body, decls);
-    let base_actions = base_actions_for(body);
-    let plan = plan_body(seed, &atoms, &head_terms);
+    let atoms = build_atoms_map(body, subst, decls);
+    let base_actions = base_actions_for(body, subst);
+    let plan = plan_body(seed, &atoms, need);
     let loads = body_load(&plan, &atoms, &base_actions);
     (plan, loads)
 }
@@ -358,14 +385,30 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
 /// Dispatches on atom kind: logic atoms (`logic::resolve`), virtual relations
 /// (`sum::SumPlan`), antijoins (`anti::Anti`), or plain data relations (a bare
 /// `BTreeSet` of variable terms).
+///
+/// `subst` lets the caller fold composition-derived constraints into the per-atom view
+/// without rewriting the atom: a body var mapped to `Term::Var(new_name)` is
+/// renamed; a body var mapped to `Term::Lit(_)` drops out of the var set (it's
+/// a known constant — the lit_filter is added by `base_actions_for`). Pass an empty
+/// `Subst` for the non-virtual planning path. Logic atoms participate in subst via
+/// `logic::resolve_with_subst`, so renamed/pushed vars also flow into their `bound`
+/// and `terms`.
 fn build_atoms_map<'a>(
     body: &'a [Atom],
+    subst: &Subst<'a>,
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
 ) -> BTreeMap<usize, Box<dyn PlanAtom<&'a String> + 'a>> {
     body.iter().enumerate().map(|(index, atom)| {
-        let terms = atom.terms.iter().filter_map(|term| term.as_var()).collect::<BTreeSet<_>>();
+        let terms: BTreeSet<&'a String> = atom.terms.iter().filter_map(|t| match t {
+            Term::Var(name) => match subst.get(name) {
+                Some(Term::Var(new_name)) => Some(new_name),
+                Some(Term::Lit(_)) => None,
+                None => Some(name),
+            },
+            Term::Lit(_) => None,
+        }).collect();
         let boxed_atom: Box<dyn PlanAtom<&'a String>+'a> =
-        if let Some(logic) = crate::rules::atoms::logic::resolve(atom) { Box::new(logic) }
+        if let Some(logic) = crate::rules::atoms::logic::resolve_with_subst(atom, subst) { Box::new(logic) }
         else if decls.get(atom.name.as_str()).map_or(false, |d| d.virt) {
             Box::new(crate::rules::atoms::sum::SumPlan { head_terms: terms })
         }
@@ -377,10 +420,63 @@ fn build_atoms_map<'a>(
 
 /// Per-atom action that materializes facts in the atom's variable-name-sorted order.
 /// Reference point for deriving plan-specific load actions.
-fn base_actions_for(body: &[Atom]) -> BTreeMap<usize, Action<Vec<u8>>> {
+///
+/// `subst` is applied while building each atom's action: a body var mapped to
+/// `Term::Lit(value)` becomes a positional literal (lit_filter); a body var
+/// mapped to `Term::Var(new_name)` is renamed (affecting var_filter detection
+/// for repeats and the projection's sort order). Pass empty `Subst` for the
+/// non-virtual path.
+fn base_actions_for<'a>(body: &[Atom], subst: &Subst<'a>) -> BTreeMap<usize, Action<Vec<u8>>> {
     body.iter().enumerate().map(|(index, atom)| {
-        let mut action = Action::from_body(atom);
-        action.projection.sort_by_key(|p| atom.terms[*p.as_ref().unwrap()].as_var().unwrap());
+        let mut action = action_from_body_with_subst(atom, subst);
+        // Sort projection by the substituted var name (the var name as the planner sees it).
+        action.projection.sort_by_key(|p| {
+            let pos = *p.as_ref().unwrap();
+            // After substitution, projection only references positions whose effective term is a Var.
+            match &atom.terms[pos] {
+                Term::Var(name) => match subst.get(name) {
+                    Some(Term::Var(new_name)) => new_name,
+                    Some(Term::Lit(_)) => unreachable!("Lit positions don't appear in projection"),
+                    None => name,
+                },
+                Term::Lit(_) => unreachable!("Lit positions don't appear in projection"),
+            }
+        });
         (index, action)
     }).collect()
+}
+
+/// Builds an `Action` from an atom, applying `subst` as it walks each term.
+///
+/// Mirrors `Action::from_body` but routes each var through `subst`: a Var → Lit
+/// substitution becomes a positional `lit_filter`; a Var → Var substitution renames
+/// (so repeats with the renamed name produce `var_filter` entries).
+fn action_from_body_with_subst<'a>(atom: &Atom, subst: &Subst<'a>) -> Action<Vec<u8>> {
+    let mut output = Action::default();
+    let mut terms_seen: BTreeMap<&str, usize> = BTreeMap::default();
+    for (index, term) in atom.terms.iter().enumerate() {
+        // Resolve to the effective post-substitution view: either a var name or lit bytes.
+        let (eff_var, eff_lit): (Option<&str>, Option<&[u8]>) = match term {
+            Term::Var(name) => match subst.get(name) {
+                Some(Term::Var(new_name)) => (Some(new_name.as_str()), None),
+                Some(Term::Lit(value)) => (None, Some(value.as_slice())),
+                None => (Some(name.as_str()), None),
+            },
+            Term::Lit(value) => (None, Some(value.as_slice())),
+        };
+        if let Some(var_name) = eff_var {
+            if !terms_seen.contains_key(var_name) {
+                let new_idx = terms_seen.len();
+                terms_seen.insert(var_name, new_idx);
+                output.var_filter.push(Vec::default());
+                output.projection.push(Ok(index));
+            }
+            output.var_filter[terms_seen[var_name]].push(index);
+        } else if let Some(value) = eff_lit {
+            output.lit_filter.push((index, value.to_vec()));
+        }
+    }
+    output.var_filter.retain(|list| list.len() > 1);
+    output.input_arity = atom.terms.len();
+    output
 }

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -17,7 +17,7 @@
 //! - [`plan_rule`] — semi-naive case. Given a body and a list of candidate *seed*
 //!   atoms (one per delta), produces one plan per seed. The seed atom's terms are
 //!   pre-bound when the stages start; the body-without-seed is sequenced.
-//! - [`plan_rule_seeded`] — virtual-atom case. The caller (e.g. a `Sum`) already holds
+//! - [`plan_rule_seeded`] — view-atom case. The caller (e.g. a `View`) already holds
 //!   bindings in a salad; it passes those terms as the seed and the full body is
 //!   sequenced.
 //!
@@ -51,7 +51,7 @@
 //!
 //! [`build_atoms_map`] dispatches each body atom to the appropriate [`PlanAtom`]
 //! implementation: data relations, antijoins (`anti::Anti`), logic atoms
-//! (`logic::resolve`), or virtual relations (`sum::SumPlan`). The planner only sees the
+//! (`logic::resolve`), or views (`view::ViewPlan`). The planner only sees the
 //! `terms()` / `ground()` interface — it doesn't care about the kind.
 
 
@@ -221,7 +221,7 @@ fn body_load<'a, A: Ord + Copy, T: Ord + Copy>(
 ///
 /// The order is of distinct terms in order of presentation, with `subst` applied
 /// (Var→Var renames are reflected; Var→Lit substitutions drop out, as do raw lits).
-/// Pass empty `Subst` for the non-virtual path.
+/// Pass empty `Subst` for the non-view path.
 fn head_order<'a>(head: &'a [Atom], subst: &Subst<'a>) -> Vec<&'a String> {
     let mut seen: BTreeSet<&'a String> = BTreeSet::default();
     head.iter()
@@ -382,15 +382,15 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
 
 /// Wraps each body atom in the appropriate `PlanAtom` implementation, keyed by body index.
 ///
-/// Dispatches on atom kind: logic atoms (`logic::resolve`), virtual relations
-/// (`sum::SumPlan`), antijoins (`anti::Anti`), or plain data relations (a bare
+/// Dispatches on atom kind: logic atoms (`logic::resolve`), views
+/// (`view::ViewPlan`), antijoins (`anti::Anti`), or plain data relations (a bare
 /// `BTreeSet` of variable terms).
 ///
 /// `subst` lets the caller fold composition-derived constraints into the per-atom view
 /// without rewriting the atom: a body var mapped to `Term::Var(new_name)` is
 /// renamed; a body var mapped to `Term::Lit(_)` drops out of the var set (it's
 /// a known constant — the lit_filter is added by `base_actions_for`). Pass an empty
-/// `Subst` for the non-virtual planning path. Logic atoms participate in subst via
+/// `Subst` for the non-view planning path. Logic atoms participate in subst via
 /// `logic::resolve_with_subst`, so renamed/pushed vars also flow into their `bound`
 /// and `terms`.
 fn build_atoms_map<'a>(
@@ -409,8 +409,8 @@ fn build_atoms_map<'a>(
         }).collect();
         let boxed_atom: Box<dyn PlanAtom<&'a String>+'a> =
         if let Some(logic) = crate::rules::atoms::logic::resolve_with_subst(atom, subst) { Box::new(logic) }
-        else if decls.get(atom.name.as_str()).map_or(false, |d| d.virt) {
-            Box::new(crate::rules::atoms::sum::SumPlan { head_terms: terms })
+        else if decls.get(atom.name.as_str()).map_or(false, |d| d.view) {
+            Box::new(crate::rules::atoms::view::ViewPlan { head_terms: terms })
         }
         else if !atom.anti { Box::new(terms) }
         else { Box::new(crate::rules::atoms::anti::Anti(terms)) };
@@ -425,7 +425,7 @@ fn build_atoms_map<'a>(
 /// `Term::Lit(value)` becomes a positional literal (lit_filter); a body var
 /// mapped to `Term::Var(new_name)` is renamed (affecting var_filter detection
 /// for repeats and the projection's sort order). Pass empty `Subst` for the
-/// non-virtual path.
+/// non-view path.
 fn base_actions_for<'a>(body: &[Atom], subst: &Subst<'a>) -> BTreeMap<usize, Action<Vec<u8>>> {
     body.iter().enumerate().map(|(index, atom)| {
         let mut action = action_from_body_with_subst(atom, subst);

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -1,4 +1,58 @@
-//! Traits and logic associated with planning rules.
+//! Rule planning: turn a rule body into a sequenced execution plan.
+//!
+//! # What this produces
+//!
+//! A [`Plan`] is a sequence of stages. Each stage names a set of atoms to apply, a set
+//! of new variable terms that stage *introduces*, and a projection target — the column
+//! order to leave the salad in before moving on. The terms across stages partition the
+//! body's variables: each variable is introduced exactly once. The final stage's target
+//! matches the rule head's variable order.
+//!
+//! Alongside each plan we compute [`Loads`]: per-atom `(Action, Vec<Term>)` instructions
+//! describing how to materialize that atom's facts in a column order compatible with
+//! the plan's stage progression.
+//!
+//! # Two entry points
+//!
+//! - [`plan_rule`] — semi-naive case. Given a body and a list of candidate *seed*
+//!   atoms (one per delta), produces one plan per seed. The seed atom's terms are
+//!   pre-bound when the stages start; the body-without-seed is sequenced.
+//! - [`plan_rule_seeded`] — virtual-atom case. The caller (e.g. a `Sum`) already holds
+//!   bindings in a salad; it passes those terms as the seed and the full body is
+//!   sequenced.
+//!
+//! Both wrappers call the same primitive — [`plan_body`] — then derive [`Loads`] via
+//! [`body_load`].
+//!
+//! # The strategy: [`plan_body`]
+//!
+//! Term-at-a-time, most-constrained-first. Start with `init_terms` (seed terms that
+//! some body atom mentions or that the head needs) and `init_atoms` (body atoms whose
+//! terms are already covered by the seed). Then repeatedly pick a not-yet-bound term
+//! reachable by some atom, introduce it as a new stage with the atoms that ground it.
+//! Adjacent single-atom stages with the same atom set get fused. Projection targets are
+//! computed by demand from later stages plus the head.
+//!
+//! # Stage 0
+//!
+//! Stage 0 is shaped differently from the rest. Its `terms` field documents the
+//! seed-relevant pre-bound bindings (the columns the executor expects to find in the
+//! salad on entry). Its `atoms` field holds `init_atoms` — body atoms whose terms are
+//! all covered by the seed and which can semijoin without introducing anything new.
+//! Stages 1+ follow the usual "this stage introduces these columns" semantics.
+//!
+//! The executor (`run_wco_stages`) handles the asymmetry: for stage 0 it semijoins
+//! against `init_atoms` over an empty introduce-set; for stages 1+ it passes `terms`
+//! through to `wco_join` as the new columns to bind. Keeping stage 0's `terms` as
+//! the starting bindings means the Plan is self-describing — `body_load` and any
+//! future consumer can read the expected starting state straight off it.
+//!
+//! # Atom kinds
+//!
+//! [`build_atoms_map`] dispatches each body atom to the appropriate [`PlanAtom`]
+//! implementation: data relations, antijoins (`anti::Anti`), logic atoms
+//! (`logic::resolve`), or virtual relations (`sum::SumPlan`). The planner only sees the
+//! `terms()` / `ground()` interface — it doesn't care about the kind.
 
 
 /// An atom over terms `T` that supports planning.
@@ -39,14 +93,266 @@ pub type Plans<A, T> = BTreeMap<A, Plan<A, T>>;
 pub type Load<T> = (Action<Vec<u8>>, Vec<T>);
 pub type Loads<A, T> = BTreeMap<A, BTreeMap<A, Load<T>>>;
 
-/// Plan the rule, generating a per-`delta_atoms` update plan.
+/// Plans a rule, producing a plan and load instructions per seed atom.
 ///
-/// Each entry in `delta_atoms` names a body atom that should take a turn as the source of
-/// novelty (the semi-naive delta). The returned plans map contains an entry for each
-/// requested delta atom that the strategy can plan (logic atoms that can't ground all
-/// their terms are silently dropped, regardless of the request).
-/// Builds the per-body-atom `PlanAtom` map that both `plan_rule` and `plan_rule_seeded`
-/// feed to the strategy. Dispatches on logic, virtual, anti, or data-relation atom kind.
+/// Each index in `seed_atoms` names a body atom that needs a plan to respond to new facts.
+/// For each seed, the atom's terms feed [`plan_body`] with all other atoms, with an output
+/// term order targeting the terms of `head`.
+///
+/// Seeds that cannot ground their own terms (e.g. logic atoms) are silently skipped.
+pub fn plan_rule<'a>(
+    head: &'a [Atom],
+    body: &'a [Atom],
+    seed_atoms: &[usize],
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+) -> (Plans<usize, &'a String>, Loads<usize, &'a String>) {
+
+    let head_terms = head_order(head);
+    let base_actions = base_actions_for(body);
+
+    let mut plans: Plans<usize, &'a String> = BTreeMap::default();
+    let mut loads: Loads<usize, &'a String> = BTreeMap::default();
+
+    // One atoms map; each iteration takes a seed_idx out as the seed and puts it back
+    // at the end. Same round-robin shape as semi-naive: the body's atoms are stable;
+    // which one supplies the novelty rotates.
+    let mut atoms = build_atoms_map(body, decls);
+    for &seed_idx in seed_atoms {
+        if let Some(seed_atom) = atoms.remove(&seed_idx) {
+            if seed_atom.terms() == seed_atom.ground(&Default::default()) {
+                let seed_terms = seed_atom.terms();
+                // Body-positional, possibly with repeats — preserves the user-written
+                // column order so the planner can prefer stage-0 atoms that align with
+                // the seed's column prefix (avoiding a re-permute on first semijoin).
+                let seed: Vec<&'a String> = body[seed_idx].terms.iter().filter_map(|t| t.as_var()).collect();
+                let plan = plan_body(&seed, &atoms, &head_terms);
+                let mut load = body_load(&plan, &atoms, &base_actions);
+                load.insert(seed_idx, seed_load(&plan, &atoms, &seed_terms, &base_actions[&seed_idx]));
+                plans.insert(seed_idx, plan);
+                loads.insert(seed_idx, load);
+            }
+            atoms.insert(seed_idx, seed_atom);
+        }
+    }
+
+    (plans, loads)
+}
+
+/// Determines the seed's own load action from an existing plan.
+///
+/// This is informed by `plan`, which reveals atoms in the first stages that we
+/// may try to align the terms of `seed` to match.
+/// It is unclear if this is worth the cost of a new form for the seed.
+fn seed_load<'a>(
+    plan: &Plan<usize, &'a String>,
+    body: &BTreeMap<usize, Box<dyn PlanAtom<&'a String> + 'a>>,
+    seed_terms: &BTreeSet<&'a String>,
+    base_action: &Action<Vec<u8>>,
+) -> Load<&'a String> {
+    let mut order = Vec::new();
+    if let Some((stage_atoms, _, _)) = plan.iter().find(|(a, _, _)| !a.is_empty()) {
+        for atom in stage_atoms.iter() {
+            for term in body[atom].terms().intersection(seed_terms) {
+                if !order.contains(term) { order.push(*term); }
+            }
+        }
+    }
+    for term in seed_terms.iter() { if !order.contains(term) { order.push(*term); } }
+
+    let mut action = base_action.clone();
+    action.projection = order.iter()
+        .flat_map(|t1| seed_terms.iter().position(|t2| t1 == t2))
+        .map(|p| base_action.projection[p].clone())
+        .collect();
+    (action, order)
+}
+
+/// Load actions for each atom in `body`.
+///
+/// For each body atom, loads the atom's terms in the order the plan binds them.
+/// This order aims to minimize the number of distinct term orders to maintain.
+pub fn body_load<'a, A: Ord + Copy, T: Ord + Copy>(
+    plan: &Plan<A, T>,
+    body: &BTreeMap<A, Box<dyn PlanAtom<T> + 'a>>,
+    base_actions: &BTreeMap<A, Action<Vec<u8>>>,
+) -> BTreeMap<A, Load<T>> {
+
+    // Term introduction order: walk stages, take each stage's new terms.
+    let mut all_terms = BTreeSet::default();
+    let mut in_order = Vec::default();
+    for (_atoms, terms, _out_order) in plan.iter() {
+        in_order.extend(terms.difference(&all_terms));
+        all_terms.extend(terms.iter().copied());
+    }
+
+    body.iter().map(|(load_atom, boxed)| {
+        let atom_terms = boxed.terms();
+        let load_terms: Vec<T> = in_order.iter().filter(|t| atom_terms.contains(t)).copied().collect();
+        let mut action = base_actions[load_atom].clone();
+        action.projection = in_order.iter()
+            .flat_map(|t1| atom_terms.iter().position(|t2| t1 == t2))
+            .map(|p| base_actions[load_atom].projection[p].clone())
+            .collect();
+        (*load_atom, (action, load_terms))
+    }).collect()
+}
+
+/// Produces a term order for head atoms.
+///
+/// The order is of distinct terms in order of presentation.
+/// Repeated terms and literals should be added in post.
+fn head_order<'a>(head: &'a [Atom]) -> Vec<&'a String> {
+    let mut seen: BTreeSet<&'a String> = BTreeSet::default();
+    head.iter().flat_map(|a| a.terms.iter()).filter_map(|t| t.as_var()).filter(|t| seen.insert(t)).collect()
+}
+
+/// Plans a single-head rule body around a caller-provided seed of pre-bound terms.
+///
+/// No body atom is treated as the seed source — `seed` is just terms. Used when the
+/// caller (e.g. a sum atom disjunct) already holds the seed bindings in an input
+/// salad and wants stages that introduce the rest of the body's variables. The single
+/// head atom matches the disjunct shape — multi-head rules don't arise on this path.
+pub fn plan_rule_seeded<'a>(
+    head: &'a Atom,
+    body: &'a [Atom],
+    seed: &[&'a String],
+    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+) -> (Plan<usize, &'a String>, BTreeMap<usize, Load<&'a String>>) {
+    let head_terms = head_order(std::slice::from_ref(head));
+    let atoms = build_atoms_map(body, decls);
+    let base_actions = base_actions_for(body);
+    let plan = plan_body(seed, &atoms, &head_terms);
+    let loads = body_load(&plan, &atoms, &base_actions);
+    (plan, loads)
+}
+
+/// Plan a body around a seed of pre-bound terms by repeatedly introducing one
+/// most-constrained term (and any atoms it newly enables) until every body term is bound.
+///
+/// The seed is *not* one of the body atoms — it represents bindings provided by the
+/// caller (the seed atom's terms in the `plan_rule` case, or a salad's terms in the
+/// `plan_rule_seeded` case). `body` is everything the planner sequences into stages.
+/// `need` is the set of terms the result must carry through to its last stage
+/// (typically the rule head's variable terms).
+///
+/// `seed` is a slice (not a set) because the caller's column order carries information
+/// the planner should use: stage-0 atoms whose terms align with a prefix of `seed` can
+/// semijoin without re-permuting the salad. The planner doesn't consult it today, but
+/// the order is meaningful — callers should pass terms in the order their salad's
+/// columns are arranged.
+pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
+    seed: &[T],
+    body: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>,
+    need: &[T],
+) -> Plan<A, T> {
+
+    let mut terms_to_atoms: BTreeMap<T, BTreeSet<A>> = Default::default();
+    for (atom, boxed) in body.iter() {
+        for term in boxed.terms() { terms_to_atoms.entry(term).or_default().insert(*atom); }
+    }
+
+    // Stage 0 carries seed terms that some body atom mentions or that the caller
+    // needs in the output. Seed terms with no constraint and no demand are pruned —
+    // there's nothing for the planner to do with them.
+    let init_terms: BTreeSet<T> =
+    seed.iter()
+        .copied()
+        .filter(|t| terms_to_atoms.contains_key(t) || need.contains(t))
+        .collect();
+    // Body atoms whose terms are all already in `init_terms` should be present in stage 0.
+    let init_atoms: BTreeSet<A> =
+    body.iter()
+        .filter(|(_, boxed)| boxed.terms().iter().all(|t| init_terms.contains(t)))
+        .map(|(a, _)| *a)
+        .collect();
+
+    let mut terms: BTreeSet<T> = init_terms.clone();
+    let mut plan: Plan<A, T> = vec![(init_atoms, init_terms, Vec::new())];
+    // Loop while there are body terms not yet bound. (We can't compare cardinalities:
+    // `terms` may include seed terms that aren't in `terms_to_atoms`, so a count
+    // match doesn't mean coverage.)
+    while terms_to_atoms.keys().any(|t| !terms.contains(t)) {
+
+        // Terms that can be grounded by some atom from the bound `terms`, not yet bound.
+        let mut next_terms = terms.iter()
+            .flat_map(|term| terms_to_atoms.get(term).into_iter().flatten())
+            .flat_map(|atom| body[atom].ground(&terms))
+            .filter(|term| !terms.contains(term) && terms_to_atoms.contains_key(term))
+            .collect::<Vec<_>>();
+
+        // Pick the term incident on the most atoms (most-constrained-first).
+        next_terms.sort_by_key(|t| terms_to_atoms[t].len());
+        // Fallback: any groundable term, allowing cross joins with data-backed atoms.
+        let next_term = next_terms.last().copied().or_else(|| body.values()
+            .flat_map(|a| a.ground(&terms))
+            .filter(|t| !terms.contains(t) && terms_to_atoms.contains_key(t))
+            .next());
+
+        if let Some(next_term) = next_term {
+            let mut next_atoms: BTreeSet<A> = terms_to_atoms[&next_term].iter()
+                .filter(|a| body[a].terms().contains(&next_term) && terms.iter().any(|t| body[a].terms().contains(t)))
+                .copied()
+                .collect();
+            next_atoms.extend(body.iter()
+                .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term))
+                .map(|(a, _)| *a));
+            if next_atoms.is_empty() {
+                next_atoms = terms_to_atoms[&next_term].iter()
+                    .filter(|a| body[a].terms().contains(&next_term))
+                    .copied()
+                    .collect();
+            }
+            terms.insert(next_term);
+            plan.push((next_atoms, [next_term].into_iter().collect(), Vec::new()));
+        }
+        else {
+            panic!("Failed to find term to extend {:?} to {:?}", terms, terms_to_atoms.keys());
+        }
+    }
+
+    // Fuse adjacent stages with the same single-atom set: the same atom introducing
+    // multiple consecutive variables is one stage, not several.
+    for index in (1 .. plan.len()).rev() {
+        if plan[index].0 == plan[index-1].0 && plan[index].0.len() == 1 {
+            let stage = plan.remove(index);
+            plan[index-1].1.extend(stage.1);
+        }
+    }
+
+    // Set each stage's projection target by demand from later stages plus `need`.
+    for index in 1 .. plan.len() {
+        let (this, rest) = plan.split_at_mut(index);
+        let present: Vec<T> = this.iter().flat_map(|(_, terms, _)| terms.iter()).copied().collect();
+        let demanded: Vec<T> = present.iter().copied().filter(|t| {
+            rest.iter().any(|(atoms, _, _)| atoms.iter().any(|a| {
+                terms_to_atoms.get(t).map_or(false, |set| set.contains(a))
+            })) || need.contains(t)
+        }).collect();
+
+        let order = &mut this[index-1].2;
+        order.clear();
+        for atom in rest[0].0.iter() {
+            for term in demanded.iter() {
+                if terms_to_atoms.get(term).map_or(false, |set| set.contains(atom)) && !order.contains(term) {
+                    order.push(*term);
+                }
+            }
+        }
+        for term in demanded.iter() { if !order.contains(term) { order.push(*term); } }
+    }
+    if let Some(last) = plan.last_mut() { last.2 = need.to_vec(); }
+
+    // Stage 0's `terms` documents the seed-relevant starting bindings; stages 1+ list
+    // the columns each stage *introduces*. `run_wco_stages` knows to treat stage 0
+    // specially (semijoin against `init_atoms`, don't try to re-introduce columns).
+    plan
+}
+
+/// Wraps each body atom in the appropriate `PlanAtom` implementation, keyed by body index.
+///
+/// Dispatches on atom kind: logic atoms (`logic::resolve`), virtual relations
+/// (`sum::SumPlan`), antijoins (`anti::Anti`), or plain data relations (a bare
+/// `BTreeSet` of variable terms).
 fn build_atoms_map<'a>(
     body: &'a [Atom],
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
@@ -64,349 +370,12 @@ fn build_atoms_map<'a>(
     }).collect()
 }
 
-/// Removes the driver from its own stage-0 atom set and clears stage 0's terms.
-/// The driver is already loaded as the seed salad; stage 0's atoms and terms in the
-/// raw plan are an artifact of the planner's projection logic.
-///
-/// Must run *after* the projection-target computation in `plan_rule`: that logic
-/// uses stage 0's `init_terms` to size the projection action, so we can't clear
-/// them until that work is done.
-fn tidy_stage_zero<'a>(plan: &mut Plan<usize, &'a String>, driver: &usize) {
-    if let Some((atoms, terms, _)) = plan.first_mut() {
-        atoms.remove(driver);
-        terms.clear();
-    }
-}
-
-pub fn plan_rule<'a, S: Strategy<usize, &'a String>>(
-    head: &'a [Atom],
-    body: &'a [Atom],
-    delta_atoms: &[usize],
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-) -> Result<(Plans<usize, &'a String>, Loads<usize, &'a String>), String> {
-
-    // We'll pick a target term order for the first head; other heads may require transforms.
-    // If we have multiple heads and one has no literals or repetitions, that would be best.
-    let head_terms = head_order(head);
-
-    let atoms = build_atoms_map(body, decls);
-
-    // We'll want to pre-plan the term orders for each atom update rule, so that we can
-    // pre-ensure that the necessary input shapes exist, with each atom in term order.
-    let mut plans = S::plan_rule(&atoms, delta_atoms, &head_terms);
-
-    // Actions for each atom that would produce the output in `terms` order.
-    // Their output columns should now be ordered as `atoms_to_terms[atom]`.
-    // We use these as reference points, and don't intend to load with them.
-    let base_actions = body.iter().enumerate().map(|(index, atom)| {
+/// Per-atom action that materializes facts in the atom's variable-name-sorted order.
+/// Reference point for deriving plan-specific load actions.
+fn base_actions_for(body: &[Atom]) -> BTreeMap<usize, Action<Vec<u8>>> {
+    body.iter().enumerate().map(|(index, atom)| {
         let mut action = Action::from_body(atom);
         action.projection.sort_by_key(|p| atom.terms[*p.as_ref().unwrap()].as_var().unwrap());
         (index, action)
-    }).collect::<BTreeMap<_,_>>();
-
-    let atoms_to_terms = atoms.iter().map(|(index, boxed)| (*index, boxed.terms())).collect::<BTreeMap<_,_>>();
-    let mut load_actions = load_actions(&plans, &atoms_to_terms, &base_actions);
-
-    // Insert loading actions for plan atoms themselves.
-    for (plan_atom, _atom) in body.iter().enumerate() {
-        if plans.contains_key(&plan_atom) {
-            // We would like to order the terms by the order they'll first be used.
-            // This is either a semijoin, if other atoms participate in the first plan step,
-            // or otherwise aligned to the order of the atoms in the second plan step.
-            // In the absence of other atoms in the first plan step or other plan steps,
-            // the default order makes sense (and we apply an action to the result).
-            let plan_terms = atoms[&plan_atom].terms();
-            let mut order = Vec::new();
-            if plans[&plan_atom][0].0.len() > 1 {
-                // The first atom that is not `plan_atom` drives the order we want.
-                // More thinking is possible here, e.g. if a different atom order would
-                // be better, or if multiple atoms align on order.
-                for atom in plans[&plan_atom][0].0.iter().filter(|a| **a != plan_atom) {
-                    let atom_terms = atoms[atom].terms();
-                    for term in plan_terms.iter() {
-                        if atom_terms.contains(term) && !order.contains(term) { order.push(*term); }
-                    }
-                }
-            }
-            else if plans[&plan_atom].len() > 1 {
-                for atom in plans[&plan_atom][1].0.iter() {
-                    let atom_terms = atoms[atom].terms();
-                    for term in plan_terms.iter() {
-                        if atom_terms.contains(term) && !order.contains(term) { order.push(*term); }
-                    }
-                }
-            }
-            for term in plan_terms.iter() { if !order.contains(term) { order.push(*term); } }
-
-            let mut action = base_actions[&plan_atom].clone();
-            action.projection =
-            order.iter()
-                 .flat_map(|t1| plan_terms.iter().position(|t2| t1 == t2))
-                 .map(|p| base_actions[&plan_atom].projection[p].clone())
-                 .collect();
-
-            load_actions.get_mut(&plan_atom).map(|l| l.insert(plan_atom, (action, order)));
-        }
-    }
-
-    // Tidy stage 0 for the executor — defer until after the projection logic above.
-    for (plan_atom, plan) in plans.iter_mut() {
-        tidy_stage_zero(plan, plan_atom);
-    }
-
-    Ok((plans, load_actions))
-}
-
-/// From per-atom plans, per-atom loading action required to for the right term order.
-///
-/// The loading instructions ensure that each occurrence of an atom in a plan has an
-/// action that will load with all prior bound terms followed by newly bound terms.
-/// In the simplest, this could just order the terms in order they are bound.
-pub fn load_actions<A: Ord + Copy, T: Ord + Copy>(
-    plans: &BTreeMap<A, Plan<A, T>>,
-    atoms_to_terms: &BTreeMap<A, BTreeSet<T>>,
-    base_actions: &BTreeMap<A, Action<Vec<u8>>>,
-) -> Loads<A, T> {
-
-    // This could be quite general, and use an arbitrary action for each atom in each stage.
-    // For example, it needn't even be the same action across uses of the same atom.
-    let mut result: Loads<A, T> = BTreeMap::default();
-    for (plan_atom, plan) in plans.iter() {
-        let mut all_terms = BTreeSet::default();
-        let mut in_order = Vec::default();
-        for (_atoms, terms, _out_order) in plan.iter() {
-            let new_terms = terms.difference(&all_terms);
-            in_order.extend(new_terms);
-            all_terms.extend(terms.iter().copied());
-        }
-        let mut loads = BTreeMap::default();
-        for load_atom in atoms_to_terms.keys().filter(|a| *a != plan_atom) {
-
-            let load_terms = in_order.iter().filter(|t| atoms_to_terms[load_atom].contains(t)).copied().collect::<Vec<_>>();
-
-            let mut action = base_actions[load_atom].clone();
-            action.projection =
-            in_order.iter()
-                    .flat_map(|t1| atoms_to_terms[load_atom].iter().position(|t2| t1 == t2))
-                    .map(|p| base_actions[load_atom].projection[p].clone())
-                    .collect();
-
-            loads.insert(*load_atom, (action, load_terms));
-        }
-        result.insert(*plan_atom, loads);
-    }
-
-    result
-}
-
-/// Produces a term order for head atoms.
-///
-/// The order is of distinct terms in order of presentation.
-/// Repeated terms and literals should be added in post.
-fn head_order<'a>(head: &'a [Atom]) -> Vec<&'a String> {
-    let mut seen: BTreeSet<&'a String> = BTreeSet::default();
-    head.iter().flat_map(|a| a.terms.iter()).filter_map(|t| t.as_var()).filter(|t| seen.insert(t)).collect()
-}
-
-/// A `PlanAtom` representing a synthetic driver whose terms are pre-bound from outside.
-///
-/// `terms()` returns the pre-bound set; `ground()` returns it for any input (the
-/// phantom can always provide its terms — they came from the caller's salad).
-struct Phantom<T> {
-    terms: BTreeSet<T>,
-}
-
-impl<T: Ord + Copy> PlanAtom<T> for Phantom<T> {
-    fn terms(&self) -> BTreeSet<T> { self.terms.clone() }
-    fn ground(&self, _: &BTreeSet<T>) -> BTreeSet<T> { self.terms.clone() }
-}
-
-/// Plans a rule body with a phantom driver representing pre-bound terms.
-///
-/// Returns a single `Plan` and the corresponding loads, both indexed by body atom
-/// position (the phantom uses index `body.len()` and is invisible to the caller).
-/// The plan is keyed for the phantom driver — execution should seed from the
-/// caller-provided salad rather than from any body atom.
-pub fn plan_rule_seeded<'a, S: Strategy<usize, &'a String>>(
-    head: &'a [Atom],
-    body: &'a [Atom],
-    pre_bound: BTreeSet<&'a String>,
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-) -> Result<(Plan<usize, &'a String>, BTreeMap<usize, Load<&'a String>>), String> {
-
-    let head_terms = head_order(head);
-    let mut atoms = build_atoms_map(body, decls);
-
-    // Insert the phantom driver at `body.len()` and use it as the sole delta atom.
-    let phantom_idx = body.len();
-    atoms.insert(phantom_idx, Box::new(Phantom { terms: pre_bound }));
-
-    let mut plans = S::plan_rule(&atoms, &[phantom_idx], &head_terms);
-    let mut plan = plans.remove(&phantom_idx).ok_or_else(|| "seeded plan failed".to_string())?;
-
-    // Compute base actions (only for body atoms; phantom isn't a real atom).
-    let base_actions = body.iter().enumerate().map(|(index, atom)| {
-        let mut action = Action::from_body(atom);
-        action.projection.sort_by_key(|p| atom.terms[*p.as_ref().unwrap()].as_var().unwrap());
-        (index, action)
-    }).collect::<BTreeMap<_,_>>();
-
-    // Compute load actions for the single phantom-driven plan.
-    let atoms_to_terms = atoms.iter().map(|(index, boxed)| (*index, boxed.terms())).collect::<BTreeMap<_,_>>();
-    let single_plan_map: BTreeMap<usize, Plan<usize, &'a String>> =
-        std::iter::once((phantom_idx, plan.clone())).collect();
-    let mut all_loads = load_actions(&single_plan_map, &atoms_to_terms, &base_actions);
-    let loads = all_loads.remove(&phantom_idx).unwrap_or_default();
-
-    tidy_stage_zero(&mut plan, &phantom_idx);
-
-    Ok((plan, loads))
-}
-
-/// A type that can produce an update plan for a rule.
-pub trait Strategy<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug> {
-    /// Plan a join to respond to changes in `atom`.
-    ///
-    /// The keys of `terms_to_atoms` are the necessary terms, which may be less than the terms announced from `atoms_to_terms`.
-    /// Each atom's `ground(terms)` method which indicates which terms the atom can produce, and it may not be the case that an
-    /// atom can ground any of their terms as a function of other ground terms.
-    fn plan_atom(atom: A, atoms_to_terms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, terms_to_atoms: &BTreeMap<T, BTreeSet<A>>) -> Plan<A, T>;
-
-    /// Plans updates for the requested `delta_atoms`.
-    ///
-    /// Each `delta_atom` is a body atom that should take a turn as the source of novelty.
-    /// Atoms that the strategy can't ground (e.g. logic atoms) are silently dropped from
-    /// the result.
-    fn plan_rule(boxed_atoms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, delta_atoms: &[A], head_terms: &[T]) -> BTreeMap<A, Plan<A, T>> {
-
-        let mut terms_to_atoms: BTreeMap<T, BTreeSet<A>> = Default::default();
-        for (atom, boxed) in boxed_atoms.iter() { for term in boxed.terms() { terms_to_atoms.entry(term).or_default().insert(*atom); } }
-
-        // Look for terms that can potentially be pruned.
-        let mut term_count: BTreeMap<T, usize> = Default::default();
-        for term in head_terms.iter() { *term_count.entry(*term).or_default() += 1; }
-        for (term, atoms) in terms_to_atoms.iter() { *term_count.entry(*term).or_default() += atoms.len(); }
-        for (_term, count) in term_count.iter() {
-            if count < &2 && boxed_atoms.len() > 1 {
-                // TODO: This is incorrect when an entire atom is pruned, e.g. as in `continue(_)`.
-                // terms_to_atoms.remove(_term);
-            }
-        }
-
-        let mut rule_plan = BTreeMap::default();
-        for atom in delta_atoms.iter().copied() {
-            if boxed_atoms.get(&atom).is_some_and(|b| b.terms() == b.ground(&Default::default())) {
-                let mut atom_plan = Self::plan_atom(atom, boxed_atoms, &terms_to_atoms);
-
-                // Fuse plan stages with identical single atoms.
-                for index in (1 .. atom_plan.len()).rev() {
-                    if atom_plan[index].0 == atom_plan[index-1].0 && atom_plan[index].0.len() == 1 {
-                        let stage = atom_plan.remove(index);
-                        atom_plan[index-1].1.extend(stage.1);
-                    }
-                }
-
-                // Plan outgoing projections, based on demand and ending with `head_terms`.
-                for index in 1 .. atom_plan.len() {
-                    let (this, rest) = atom_plan.split_at_mut(index);
-                    let present = this.iter().flat_map(|(_, terms, _)| terms.iter()).copied().collect::<Vec<_>>();
-                    let demanded = present.iter().copied().filter(|t| rest.iter().any(|(atoms,_,_)| atoms.iter().any(|a| terms_to_atoms[t].contains(a)) || head_terms.contains(t))).collect::<Vec<_>>();
-
-                    // Set the target order by the terms in common with atoms of the next stage, in atom order, then uninvolved terms.
-                    let order = &mut this[index-1].2;
-                    order.clear();
-                    for atom in rest[0].0.iter() {
-                        for term in demanded.iter() {
-                            if terms_to_atoms[term].contains(atom) && !order.contains(term) { order.push(*term); }
-                        }
-                    }
-                    for term in demanded.iter() { if !order.contains(term) { order.push(*term); } }
-
-                }
-                atom_plan.last_mut().unwrap().2 = head_terms.to_vec();
-
-                rule_plan.insert(atom, atom_plan);
-            }
-        }
-        rule_plan
-    }
-}
-
-/// Plans updates for an atom by repeatedly introducing individual terms and all supported atoms.
-pub struct ByTerm;
-impl<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug> Strategy<A, T> for ByTerm {
-    fn plan_atom(atom: A, atoms_to_terms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, terms_to_atoms: &BTreeMap<T, BTreeSet<A>>) -> Plan<A, T> {
-
-        // TODO: Reason about which terms are needed to produce (e.g. avoid singly mentioned variables).
-        assert!(atoms_to_terms[&atom].terms() == atoms_to_terms[&atom].ground(&Default::default()));
-
-        let init_terms: BTreeSet<T> = atoms_to_terms[&atom].terms().into_iter().filter(|t| terms_to_atoms.contains_key(t)).collect();
-        let init_atoms: BTreeSet<A> = init_terms.iter().flat_map(|t| terms_to_atoms[t].iter()).filter(|a| atoms_to_terms[a].terms().iter().all(|t| init_terms.contains(t))).copied().collect();
-
-        // One approach: grow terms through adjacent atoms.
-        let mut terms: BTreeSet<T> = init_terms.clone();
-        let mut plan: Plan<A, T> = vec![(init_atoms, init_terms, Vec::new())];
-        while terms.len() < terms_to_atoms.len() {
-
-            // Terms that can be ground through an atom from `terms`, but not yet in `terms`.
-            let mut next_terms =
-            terms.iter()
-                 .flat_map(|term| terms_to_atoms[term].iter())
-                 .flat_map(|atom| atoms_to_terms[atom].ground(&terms))
-                 .filter(|term| !terms.contains(term) && terms_to_atoms.contains_key(term))
-                 .collect::<Vec<_>>();
-
-            // Choose the term incident on the most atoms.
-            next_terms.sort_by_key(|t| terms_to_atoms[t].len());
-            // If we can't find a term, we'll need to pick any groundable term (e.g. a cross join with a data-backed relation).
-            if let Some(next_term) = next_terms.last().copied().or_else(|| atoms_to_terms.values().flat_map(|a| a.ground(&terms)).filter(|t| !terms.contains(t) && terms_to_atoms.contains_key(t)).next()) {
-                let mut next_atoms: BTreeSet<A> = terms_to_atoms[&next_term].iter().filter(|a| atoms_to_terms[a].terms().contains(&next_term) && terms.iter().any(|t| atoms_to_terms[a].terms().contains(t))).copied().collect();
-                // Also include atoms that can ground `next_term` independently (e.g. cross-join with a data relation).
-                next_atoms.extend(atoms_to_terms.iter().filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term)).map(|(a, _)| *a));
-                if next_atoms.is_empty() { next_atoms = terms_to_atoms[&next_term].iter().filter(|a| atoms_to_terms[a].terms().contains(&next_term)).copied().collect(); }
-                terms.insert(next_term);
-                plan.push((next_atoms, [next_term].into_iter().collect(), Vec::new()));
-            }
-            else {
-                panic!("Failed to find term to extend {:?} to {:?}", terms, terms_to_atoms.keys());
-            }
-        }
-        plan
-    }
-}
-
-/// Plans updates for an atom by repeatedly adding individual atoms and all of their terms.
-pub struct ByAtom;
-impl<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug> Strategy<A, T> for ByAtom {
-    fn plan_atom(atom: A, atoms_to_terms: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>, terms_to_atoms: &BTreeMap<T, BTreeSet<A>>) -> Plan<A, T> {
-
-        assert!(atoms_to_terms[&atom].terms() == atoms_to_terms[&atom].ground(&Default::default()));
-
-        // We start with `atom`, but also semijoin subsumed atoms.
-        let init_atoms: BTreeSet<A> = [atom].into_iter().collect();
-        let init_terms: BTreeSet<T> = atoms_to_terms[&atom].terms();
-
-        // One approach: grow terms through adjacent atoms.
-        let mut atoms: BTreeSet<A> = init_atoms.clone();
-        let mut terms = init_terms.clone();
-        let mut plan: Plan<A, T> = vec![(init_atoms, init_terms, Vec::new())];
-        while atoms.len() < atoms_to_terms.len() {
-
-            // Atoms are available if they can be fully enumerated from the bound terms.
-            let mut next_atoms =
-            atoms.iter()
-                 .flat_map(|atom| atoms_to_terms[atom].terms())
-                 .flat_map(|term| terms_to_atoms[&term].iter())
-                 .filter(|atom| !atoms.contains(atom) && atoms_to_terms[atom].terms().difference(&atoms_to_terms[atom].ground(&terms)).all(|t| terms.contains(t)));
-
-            // Choose the first available atom. This can be dramatically improved.
-            let next_atom = next_atoms.next().unwrap_or_else(|| atoms_to_terms.keys().find(|a| !atoms.contains(a)).unwrap());
-            let next_terms: BTreeSet<_> = atoms_to_terms[next_atom].terms().iter().filter(|t| terms_to_atoms[t].iter().all(|a| !atoms.contains(a))).copied().collect();
-            terms.extend(next_terms.iter().copied());
-
-            atoms.insert(*next_atom);
-            plan.push(([*next_atom].into_iter().collect(), next_terms, Vec::new()));
-        }
-        plan
-    }
+    }).collect()
 }


### PR DESCRIPTION
A fair bit of Claude-assisted work to support "views": rules that do not materialize their head, and instead participate in joins as disjuncts of conjuncts. Informally, you would write
```
.decl Foo(_, _) view

Foo(x, y) :- ...
Foo(x, y) :- ...

Bar(a, b, c) :- Foo(a, b), .. 
```
and the use of `Foo(a, b)` in `Bar` is as an `ExecAtom` that can both surface new facts and effect a join with a subset of bound terms. It does not do much of anything with `ExecAtom::count` at the moment, but .. in principle this could improve.

There are various cute things, mainly around literal constraints, where one can simplify and prune various rules that could not occur. For example,
```
.decl Foo(_, _) view

Foo(1, x) :- :print(x) .

Bar(x) :- :range(0, x, 10), Foo(0, x) .
Baz(x) :- :range(0, x, 10), Foo(1, x) .
```
Only the `Baz` rule will result in printed output, as the `Bar` rule can be seen to be inconsistent with the `Foo` rule head. Whether this optimization is a great idea, or a source of optimization frustration around side-effects, is to be seen.