### PR TITLE
Owned terms

### DIFF
--- a/src/rules/atoms/anti.rs
+++ b/src/rules/atoms/anti.rs
@@ -10,12 +10,12 @@ use crate::comms::Comms;
 /// Wrapper type for antijoins.
 pub struct Anti<T>(pub T);
 
-impl <T: Ord + Copy> PlanAtom<T> for Anti<BTreeSet<T>> {
+impl <T: Ord + Clone> PlanAtom<T> for Anti<BTreeSet<T>> {
     fn terms(&self) -> BTreeSet<T> { self.0.clone() }
     fn ground(&self, _terms: &BTreeSet<T>) -> BTreeSet<T> { Default::default() }
 }
 
-impl<T: Ord + Copy+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<Forest<Terms>>, Vec<T>)> {
+impl<T: Ord + Clone+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<Forest<Terms>>, Vec<T>)> {
 
     fn terms(&self) -> &[T] { &self.0.1 }
 
@@ -26,7 +26,7 @@ impl<T: Ord + Copy+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<Forest<Terms>>, Ve
     fn join(&self, comms: &mut Comms, salad: &mut Salad<T>, terms: &BTreeSet<T>, _after: &[T]) {
         let (my_facts, my_terms) = &self.0;
         let prefix = my_terms.iter().take_while(|t| salad.terms.contains(t)).count();
-        salad.align_to(comms, my_terms[..prefix].iter().copied());
+        salad.align_to(comms, my_terms[..prefix].iter().cloned());
         // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
         assert!(prefix > 0 || comms.peers() == 1);
         if let Some(delta) = salad.facts.flatten() {

--- a/src/rules/atoms/data.rs
+++ b/src/rules/atoms/data.rs
@@ -8,12 +8,12 @@ use crate::rules::{PlanAtom, ExecAtom};
 use crate::rules::exec::Salad;
 use crate::comms::Comms;
 
-impl<T: Ord + Copy> PlanAtom<T> for BTreeSet<T> {
+impl<T: Ord + Clone> PlanAtom<T> for BTreeSet<T> {
     fn terms(&self) -> BTreeSet<T> { self.clone() }
     fn ground(&self, terms: &BTreeSet<T>) -> BTreeSet<T> { self.difference(terms).cloned().collect() }
 }
 
-impl<T: Ord + Copy + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<T>, Option<Forest<Terms>>) {
+impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<T>, Option<Forest<Terms>>) {
 
     fn terms(&self) -> &[T] { &self.1 }
 
@@ -34,7 +34,7 @@ impl<T: Ord + Copy + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<T
         let (other_facts, other_terms, _other_recent) = self;
 
         let prefix = other_terms.iter().take_while(|t| salad.terms.contains(t)).count();
-        salad.align_to(comms, other_terms[..prefix].iter().copied());
+        salad.align_to(comms, other_terms[..prefix].iter().cloned());
         // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
         assert!(prefix > 0 || comms.peers() == 1);
         if let Some(mut delta) = salad.facts.flatten() {
@@ -105,14 +105,14 @@ impl<T: Ord + Copy + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<T
     fn join(&self, comms: &mut Comms, salad: &mut Salad<T>, terms: &BTreeSet<T>, after: &[T]) {
         let (my_facts, my_terms, _) = self;
         let prefix = my_terms.iter().take_while(|t| salad.terms.contains(t)).count();
-        salad.align_to(comms, my_terms[..prefix].iter().copied());
+        salad.align_to(comms, my_terms[..prefix].iter().cloned());
         // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
         assert!(prefix > 0 || comms.peers() == 1);
         if !terms.is_empty() {
             // join with atom: permute `salad.terms` into the right order, join adding the new column, permute into target order (`delta_terms_new`).
             let conduit = comms.conduit();
             if let Some(delta) = salad.facts.flatten() {
-                let join_terms = salad.terms.iter().chain(salad.terms[..prefix].iter()).chain(terms.iter()).copied().collect::<Vec<_>>();
+                let join_terms = salad.terms.iter().chain(salad.terms[..prefix].iter()).chain(terms.iter()).cloned().collect::<Vec<_>>();
                 // Our output join order (until we learn how to do FDB shapes) is the first of `others` not equal to ourself.
                 let projection = after.iter().map(|t| join_terms.iter().position(|t2| t == t2).unwrap()).collect::<Vec<_>>();
                 salad.facts.extend(delta.join_many(my_facts.iter(), prefix, &projection[..], conduit));

--- a/src/rules/atoms/logic.rs
+++ b/src/rules/atoms/logic.rs
@@ -20,14 +20,14 @@ use crate::comms::Comms;
 /// Looks for the atom's name in a known list, and returns an implementation if found.
 ///
 /// The implementation is a type that implements both `PlanAtom` and `ExecAtom`, and can be boxed as either.
-pub fn resolve(atom: &Atom) -> Option<LogicRel<&String>> {
+pub fn resolve(atom: &Atom) -> Option<LogicRel<String>> {
     resolve_with_subst(atom, &plan::Subst::new())
 }
 
 /// Substitution-aware variant of `resolve`. Used by view planning so that head-var
 /// renames (and lit pushdown) flow into the logic atom's `bound`/`terms`. For the
 /// non-view path, an empty `subst` (via `resolve`) gives the original behavior.
-pub fn resolve_with_subst<'a>(atom: &'a Atom, subst: &plan::Subst<'a>) -> Option<LogicRel<&'a String>> {
+pub fn resolve_with_subst<'a>(atom: &'a Atom, subst: &plan::Subst) -> Option<LogicRel<String>> {
     match atom.name.as_str() {
         ":noteq" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::NotEq } ), atom, subst)),
         ":range" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Range } ), atom, subst)),
@@ -93,7 +93,7 @@ pub struct LogicRel<T> {
     pub terms: Vec<T>,
 }
 
-impl<'a> LogicRel<&'a String> {
+impl<'a> LogicRel<String> {
     /// Create a new instance of `Self` from batch logic and the atom itself.
     pub fn new(logic: Box<dyn super::logic::BatchLogic>, atom: &'a Atom) -> Self {
         Self::new_with_subst(logic, atom, &plan::Subst::new())
@@ -105,13 +105,13 @@ impl<'a> LogicRel<&'a String> {
     pub fn new_with_subst(
         logic: Box<dyn super::logic::BatchLogic>,
         atom: &'a Atom,
-        subst: &plan::Subst<'a>,
+        subst: &plan::Subst,
     ) -> Self {
-        let bound: Vec<Result<&'a String, Vec<u8>>> = atom.terms.iter().map(|t| match t {
+        let bound: Vec<Result<String, Vec<u8>>> = atom.terms.iter().map(|t| match t {
             Term::Var(name) => match subst.get(name).cloned() {
                 Some(Term::Var(new_name)) => Ok(new_name),
                 Some(Term::Lit(data)) => Err(data.clone()),
-                None => Ok(name),
+                None => Ok(name.clone()),
             },
             Term::Lit(data) => Err(data.clone()),
         }).collect();

--- a/src/rules/atoms/logic.rs
+++ b/src/rules/atoms/logic.rs
@@ -21,19 +21,12 @@ use crate::comms::Comms;
 ///
 /// The implementation is a type that implements both `PlanAtom` and `ExecAtom`, and can be boxed as either.
 pub fn resolve(atom: &Atom) -> Option<LogicRel<String>> {
-    resolve_with_subst(atom, &plan::Subst::new())
-}
-
-/// Substitution-aware variant of `resolve`. Used by view planning so that head-var
-/// renames (and lit pushdown) flow into the logic atom's `bound`/`terms`. For the
-/// non-view path, an empty `subst` (via `resolve`) gives the original behavior.
-pub fn resolve_with_subst<'a>(atom: &'a Atom, subst: &plan::Subst) -> Option<LogicRel<String>> {
     match atom.name.as_str() {
-        ":noteq" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::NotEq } ), atom, subst)),
-        ":range" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Range } ), atom, subst)),
-        ":plus"  => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Plus } ),  atom, subst)),
-        ":times" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Times } ), atom, subst)),
-        ":print" => Some(LogicRel::new_with_subst(Box::new(BatchedLogic { logic: relations::Print(atom.terms.len()) } ), atom, subst)),
+        ":noteq" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::NotEq } ), atom)),
+        ":range" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Range } ), atom)),
+        ":plus"  => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Plus } ),  atom)),
+        ":times" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Times } ), atom)),
+        ":print" => Some(LogicRel::new(Box::new(BatchedLogic { logic: relations::Print(atom.terms.len()) } ), atom)),
         _ => None,
     }
 }
@@ -93,26 +86,11 @@ pub struct LogicRel<T> {
     pub terms: Vec<T>,
 }
 
-impl<'a> LogicRel<String> {
+impl LogicRel<String> {
     /// Create a new instance of `Self` from batch logic and the atom itself.
-    pub fn new(logic: Box<dyn super::logic::BatchLogic>, atom: &'a Atom) -> Self {
-        Self::new_with_subst(logic, atom, &plan::Subst::new())
-    }
-
-    /// Substitution-aware variant: walks atom terms applying `subst`, so a body var
-    /// renamed via `Term::Var(new_name)` appears under its new name in `bound`/`terms`,
-    /// and a body var pushed down to `Term::Lit(value)` becomes a positional literal.
-    pub fn new_with_subst(
-        logic: Box<dyn super::logic::BatchLogic>,
-        atom: &'a Atom,
-        subst: &plan::Subst,
-    ) -> Self {
+    pub fn new(logic: Box<dyn super::logic::BatchLogic>, atom: &Atom) -> Self {
         let bound: Vec<Result<String, Vec<u8>>> = atom.terms.iter().map(|t| match t {
-            Term::Var(name) => match subst.get(name).cloned() {
-                Some(Term::Var(new_name)) => Ok(new_name),
-                Some(Term::Lit(data)) => Err(data.clone()),
-                None => Ok(name.clone()),
-            },
+            Term::Var(name) => Ok(name.clone()),
             Term::Lit(data) => Err(data.clone()),
         }).collect();
         let terms = bound.iter().flatten().collect::<BTreeSet<_>>().into_iter().cloned().collect::<Vec<_>>();

--- a/src/rules/atoms/logic.rs
+++ b/src/rules/atoms/logic.rs
@@ -108,30 +108,30 @@ impl<'a> LogicRel<&'a String> {
         subst: &plan::Subst<'a>,
     ) -> Self {
         let bound: Vec<Result<&'a String, Vec<u8>>> = atom.terms.iter().map(|t| match t {
-            Term::Var(name) => match subst.get(name).copied() {
+            Term::Var(name) => match subst.get(name).cloned() {
                 Some(Term::Var(new_name)) => Ok(new_name),
                 Some(Term::Lit(data)) => Err(data.clone()),
                 None => Ok(name),
             },
             Term::Lit(data) => Err(data.clone()),
         }).collect();
-        let terms = bound.iter().flatten().collect::<BTreeSet<_>>().into_iter().copied().collect::<Vec<_>>();
+        let terms = bound.iter().flatten().collect::<BTreeSet<_>>().into_iter().cloned().collect::<Vec<_>>();
         Self { logic, bound, terms }
     }
 }
 
-impl <T: Ord + Copy> plan::PlanAtom<T> for LogicRel<T> {
+impl <T: Ord + Clone> plan::PlanAtom<T> for LogicRel<T> {
     fn terms(&self) -> BTreeSet<T> { self.terms.iter().cloned().collect() }
     fn ground(&self, terms: &BTreeSet<T>) -> BTreeSet<T> {
         let indexes = self.bound.iter().enumerate().filter(|(_index, term)| match term {
             Ok(name) => terms.contains(name),
             Err(_) => true,
         }).map(|(index,_term)| index).collect();
-        self.logic.bound(&indexes).into_iter().map(|index| self.bound[index].as_ref().unwrap()).copied().collect()
+        self.logic.bound(&indexes).into_iter().map(|index| self.bound[index].as_ref().unwrap()).cloned().collect()
     }
 }
 
-impl<T: Ord + Copy> exec::ExecAtom<T> for LogicRel<T> {
+impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
 
     // Lightly odd, in that we have no preference on term order.
     fn terms(&self) -> &[T] { &self.terms }
@@ -141,7 +141,7 @@ impl<T: Ord + Copy> exec::ExecAtom<T> for LogicRel<T> {
         else {
             let mut salad = crate::rules::exec::Salad::new(Default::default(), Vec::default());
             salad.extend([Vec::default().try_into().unwrap()]);
-            self.join(comms, &mut salad, &self.terms.iter().copied().collect(), &self.terms);
+            self.join(comms, &mut salad, &self.terms.iter().cloned().collect(), &self.terms);
             salad
         }
     }
@@ -264,11 +264,11 @@ impl<T: Ord + Copy> exec::ExecAtom<T> for LogicRel<T> {
                     delta.push_layer(Rc::new(Layer { list: colnew }));
                     salad.facts.push(delta);
                 }
-                salad.terms.push(*added.iter().next().unwrap());
+                salad.terms.push(added.iter().next().unwrap().clone());
             }
 
         }
-        else { Extend::extend(&mut salad.terms, added.iter().take(1).copied()); }
+        else { Extend::extend(&mut salad.terms, added.iter().take(1).cloned()); }
     }
 }
 
@@ -282,7 +282,7 @@ impl<L: Logic> BatchLogic for BatchedLogic<L> {
         // The following is .. neither clear nor performant. It should be at least one of those two things.
         let length = args.iter().flatten().next().map(|a| a.1.iter().sum()).unwrap_or(1);
         let mut counts = Vec::with_capacity(length);
-        let mut indexs = args.iter().map(|opt| opt.as_ref().map(|(_, counts)| counts.iter().copied().enumerate().flat_map(|(index, count)| std::iter::repeat(index).take(count)))).collect::<Vec<_>>();
+        let mut indexs = args.iter().map(|opt| opt.as_ref().map(|(_, counts)| counts.iter().cloned().enumerate().flat_map(|(index, count)| std::iter::repeat(index).take(count)))).collect::<Vec<_>>();
         let mut values: Vec<Option<<Terms as columnar::Borrow>::Ref<'_>>> = Vec::default();
         for _ in 0 .. length {
             values.clear();
@@ -296,7 +296,7 @@ impl<L: Logic> BatchLogic for BatchedLogic<L> {
 
         // The following is .. neither clear nor performant. It should be at least one of those two things.
         let length = args.iter().flatten().next().map(|a| a.1.iter().sum()).unwrap_or(1);
-        let mut indexs = args.iter().map(|opt| opt.as_ref().map(|(_, counts)| counts.iter().copied().enumerate().flat_map(|(index, count)| std::iter::repeat(index).take(count)))).collect::<Vec<_>>();
+        let mut indexs = args.iter().map(|opt| opt.as_ref().map(|(_, counts)| counts.iter().cloned().enumerate().flat_map(|(index, count)| std::iter::repeat(index).take(count)))).collect::<Vec<_>>();
         let mut values: Vec<Option<<Terms as columnar::Borrow>::Ref<'_>>> = Vec::default();
         let mut terms = Terms::default();
         let mut result: Options<Lists<Terms>> = Default::default();

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -6,7 +6,6 @@
 //! fields are documented on the struct.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::comms::Comms;
@@ -15,16 +14,6 @@ use crate::rules::exec::Salad;
 use crate::rules::plan::{self, PlanAtom};
 use crate::rules::{ExecAtom, SeedExec, StageExec};
 use crate::types::{Action, Atom, RelationDecl, Rule, Term};
-
-/// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
-///
-/// Lives 'static so it can coerce to any `String`. `wco_join` runs on salads
-/// whose term type is `String` for an `'a` we don't own; a local `String`
-/// declared inside `View::seed`/`View::join_seeded` wouldn't live long enough.
-fn potato() -> &'static String {
-    static POTATO: OnceLock<String> = OnceLock::new();
-    POTATO.get_or_init(|| ".potato".to_string())
-}
 
 /// PlanAtom proxy for view references — no apparatus, just term info.
 pub struct ViewPlan {
@@ -256,7 +245,7 @@ impl ExecAtom<String> for View {
         let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
         for disjunct in &self.seed_disjuncts {
             let mut salad = disjunct.seed.seed(comms, recent);
-            crate::rules::run_wco_stages(comms, &mut salad, &disjunct.stages, potato().clone());
+            crate::rules::run_wco_stages(comms, &mut salad, &disjunct.stages);
             let projected = project_through_head(salad, &disjunct.head, &self.use_site);
             result.facts.extend(projected.facts);
         }
@@ -312,9 +301,7 @@ impl View {
                 &canonical, &disjunct.input_action, disjunct.seed_terms_for_action(),
             );
             if disjunct_salad.facts.is_empty() { continue; }
-            crate::rules::run_wco_stages(
-                comms, &mut disjunct_salad, &disjunct.stages, potato().clone(),
-            );
+            crate::rules::run_wco_stages(comms, &mut disjunct_salad, &disjunct.stages);
             let projected = apply_action_to_salad(
                 &disjunct_salad, &disjunct.output_action, self.head_terms.clone(),
             );

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use crate::comms::Comms;
 use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
 use crate::rules::exec::Salad;
-use crate::rules::plan::{self, PlanAtom, Subst};
+use crate::rules::plan::{self, PlanAtom};
 use crate::rules::{ExecAtom, SeedApparatus, StageBoxes};
 use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
@@ -38,12 +38,14 @@ impl PlanAtom<String> for ViewPlan {
     }
 }
 
-/// One disjunct of the seed apparatus: defining rule plus its standard apparatus.
-pub struct SeedDisjunct<'a> {
-    pub rule: &'a Rule,
+/// One disjunct of the seed apparatus: cloned head atom plus its standard apparatus.
+pub struct SeedDisjunct {
+    /// The disjunct's head atom (cloned from the defining rule). Used by `View::seed`
+    /// to project results through the head's positional shape.
+    pub head: Atom,
     pub plans: plan::Plans<usize, String>,
     pub loads: plan::Loads<usize, String>,
-    pub apparatus: SeedApparatus<'a>,
+    pub apparatus: SeedApparatus,
 }
 
 /// One disjunct of the join apparatus: the seeded plan for the disjunct's body and
@@ -51,8 +53,7 @@ pub struct SeedDisjunct<'a> {
 ///
 /// At runtime, evaluation is: canonicalize input salad to pattern order → apply
 /// `input_action` → run plan stages → apply `output_action` → use-site-shaped salad.
-pub struct JoinDisjunct<'a> {
-    pub rule: &'a Rule,
+pub struct JoinDisjunct {
     /// Applied to the (canonicalized) input salad before passing into the plan.
     /// Filters by use-site/head-derived constraints not pushable via substitution
     /// (e.g. head literal at use-site var position in pattern); projects to the
@@ -65,28 +66,29 @@ pub struct JoinDisjunct<'a> {
     /// The seeded plan for the disjunct's body, planned with substitution applied.
     pub plan: plan::Plan<usize, String>,
     /// Pre-built atoms per stage, in plan order (one per atom in each stage).
-    pub stages: Vec<StageBoxes<'a>>,
+    pub stages: Vec<StageBoxes>,
 }
 
 /// Pre-built apparatus for `View::join` for one specific approach pattern.
-pub struct JoinApparatus<'a> {
-    /// The pre-bound subset of sum's terms (in use-site space).
+pub struct JoinApparatus {
+    /// The pre-bound subset of view's terms (in use-site space).
     pub pattern: BTreeSet<String>,
-    pub disjuncts: Vec<JoinDisjunct<'a>>,
+    pub disjuncts: Vec<JoinDisjunct>,
 }
 
 /// ExecAtom for a view reference.
-pub struct View<'a> {
-    pub use_site: &'a Atom,
+pub struct View {
+    /// The use-site atom (cloned at build time). Used by `View::seed` to shape output.
+    pub use_site: Atom,
     pub head_terms: Vec<String>,
-    /// Apparatus for `seed` (when sum is itself the seed). Always present.
-    pub seed_disjuncts: Vec<SeedDisjunct<'a>>,
+    /// Apparatus for `seed` (when view is itself the seed). Always present.
+    pub seed_disjuncts: Vec<SeedDisjunct>,
     /// Apparatus for `join` for a single pre-known approach pattern. Present when
     /// the construction site identified a pattern via the parent plan.
-    pub join_apparatus: Option<JoinApparatus<'a>>,
+    pub join_apparatus: Option<JoinApparatus>,
 }
 
-impl<'a> View<'a> {
+impl View {
     /// Constructs a `View` for a view reference at `body[load_atom]`.
     ///
     /// Always builds the seed apparatus from the view's defining rules.
@@ -99,37 +101,40 @@ impl<'a> View<'a> {
     pub fn build(
         facts: &mut Relations,
         comms: &mut Comms,
-        decls: &'a std::collections::BTreeMap<String, RelationDecl>,
-        rules: &'a [(Rule, Vec<Duration>)],
-        body: &'a [Atom],
+        decls: &std::collections::BTreeMap<String, RelationDecl>,
+        rules: &[(Rule, Vec<Duration>)],
+        body: &[Atom],
         plan_atom: usize,
         load_atom: usize,
         parent_plan: Option<&plan::Plan<usize, String>>,
-    ) -> View<'a> {
+    ) -> View {
         let view_name = body[load_atom].name.as_str();
-        let defining: Vec<&'a Rule> = rules.iter()
+        let defining: Vec<&Rule> = rules.iter()
             .map(|(r, _)| r)
             .filter(|r| !r.head.is_empty() && r.head[0].name.as_str() == view_name)
             .collect();
 
-        let mut seed_disjuncts: Vec<SeedDisjunct<'a>> = Vec::with_capacity(defining.len());
+        let mut seed_disjuncts: Vec<SeedDisjunct> = Vec::with_capacity(defining.len());
         for rule in &defining {
             let (plans, loads, apparatus) = crate::rules::plan_and_build_with_fields(
                 facts, comms, decls, rules,
                 &rule.body[..], &rule.head[..],
                 true, None,
             );
-            seed_disjuncts.push(SeedDisjunct { rule, plans, loads, apparatus });
+            seed_disjuncts.push(SeedDisjunct {
+                head: rule.head[0].clone(),
+                plans, loads, apparatus,
+            });
         }
 
-        let use_site = &body[load_atom];
-        let head_terms: Vec<String> = use_site.terms.iter().filter_map(|t| t.as_var().cloned()).collect();
+        let use_site_atom = body[load_atom].clone();
+        let head_terms: Vec<String> = use_site_atom.terms.iter().filter_map(|t| t.as_var().cloned()).collect();
 
         let join_apparatus = parent_plan.and_then(|plan| {
-            build_join_apparatus(facts, comms, decls, rules, plan, body, plan_atom, load_atom, &defining, use_site)
+            build_join_apparatus(facts, comms, decls, rules, plan, body, plan_atom, load_atom, &defining, &use_site_atom)
         });
 
-        View { use_site, head_terms, seed_disjuncts, join_apparatus }
+        View { use_site: use_site_atom, head_terms, seed_disjuncts, join_apparatus }
     }
 }
 
@@ -139,18 +144,18 @@ impl<'a> View<'a> {
 /// Returns `None` if the load atom isn't found in any plan stage. Per-disjunct,
 /// `compose_disjunct` may return `None` (lit-vs-lit contradiction or substitution
 /// conflict) and the disjunct is silently dropped from the apparatus.
-fn build_join_apparatus<'a>(
+fn build_join_apparatus(
     facts: &mut Relations,
     comms: &mut Comms,
-    decls: &'a std::collections::BTreeMap<String, RelationDecl>,
-    rules: &'a [(Rule, Vec<Duration>)],
+    decls: &std::collections::BTreeMap<String, RelationDecl>,
+    rules: &[(Rule, Vec<Duration>)],
     plan: &plan::Plan<usize, String>,
-    body: &'a [Atom],
+    body: &[Atom],
     plan_atom: usize,
     load_atom: usize,
-    defining: &[&'a Rule],
-    use_site: &'a Atom,
-) -> Option<JoinApparatus<'a>> {
+    defining: &[&Rule],
+    use_site: &Atom,
+) -> Option<JoinApparatus> {
 
     // Find the stage in `plan` containing `load_atom`.
     let stage_idx = plan.iter().position(|(stage_atoms, _, _)| stage_atoms.contains(&load_atom))?;
@@ -186,40 +191,42 @@ fn build_join_apparatus<'a>(
         };
 
     // Build per-disjunct join apparatus.
-    let mut disjuncts: Vec<JoinDisjunct<'a>> = Vec::with_capacity(defining.len());
+    let mut disjuncts: Vec<JoinDisjunct> = Vec::with_capacity(defining.len());
     for rule in defining {
         let disjunct_head = &rule.head[0];
 
         // Compose use-site request with this disjunct's head. `None` means the
         // disjunct contributes nothing (lit-vs-lit contradiction or substitution
         // conflict) — we silently skip it.
-        let comp = match compose_disjunct(&pattern, use_site, disjunct_head) {
+        let comp = match compose_disjunct(&pattern, use_site, disjunct_head, &rule.body[..]) {
             Some(c) => c,
             None => continue,
         };
 
-        let (plan, loads) = plan::plan_rule_seeded(
-            &rule.body[..], &comp.seed, &comp.need, &comp.subst, decls,
-        );
+        // The composition produced a rewritten body (substitution applied) which is
+        // owned locally. Plan, loads, and stage boxes don't borrow from it — data
+        // and logic atoms own their data, and `View` (via `View::build`) clones any
+        // atoms it needs. So `comp.body` can drop at the end of this iteration.
+        let body = &comp.body[..];
+
+        let (plan, loads) = plan::plan_rule_seeded(body, &comp.seed, &comp.need, decls);
 
         // Ensure index actions for each load action in the seeded plan.
-        crate::rules::ensure_actions_for_loads(facts, comms, decls, &rule.body[..], &loads);
+        crate::rules::ensure_actions_for_loads(facts, comms, decls, body, &loads);
 
         // Build per-stage atoms. Pass `pattern_info: None` so any nested views
         // in the disjunct's body fall back to materialize for now.
-        let stages: Vec<StageBoxes<'a>> = plan.iter()
+        let stages: Vec<StageBoxes> = plan.iter()
             .map(|(atoms, _, _)| atoms.iter()
                 .map(|inner_load| crate::rules::build_atom(
                     facts, comms, decls, rules,
-                    &rule.body[..], 0, *inner_load, &loads,
+                    body, 0, *inner_load, &loads,
                     None,
-                    &comp.subst,
                 ))
                 .collect::<Vec<_>>())
             .collect();
 
         disjuncts.push(JoinDisjunct {
-            rule,
             input_action: comp.input_action,
             output_action: comp.output_action,
             plan,
@@ -230,17 +237,16 @@ fn build_join_apparatus<'a>(
     Some(JoinApparatus { pattern, disjuncts })
 }
 
-impl<'a> ExecAtom<String> for View<'a> {
+impl ExecAtom<String> for View {
     fn terms(&self) -> &[String] { &self.head_terms[..] }
 
     fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<String> {
         let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
         for disjunct in &self.seed_disjuncts {
-            let disjunct_head = &disjunct.rule.head[0];
             for ((_plan_atom, plan), (driver, stages)) in disjunct.plans.iter().zip(&disjunct.apparatus) {
                 let mut salad = driver.seed(comms, recent);
                 crate::rules::run_wco_stages(comms, &mut salad, plan, stages, potato().clone());
-                let projected = project_through_head(salad, disjunct_head, self.use_site);
+                let projected = project_through_head(salad, &disjunct.head, &self.use_site);
                 result.facts.extend(projected.facts);
             }
         }
@@ -275,10 +281,10 @@ impl<'a> ExecAtom<String> for View<'a> {
     }
 }
 
-impl<'a> View<'a> {
+impl View {
     /// Seeded-evaluation join: run each disjunct constrained by the input salad,
     /// project results back to use-site space, replace `salad` with the union.
-    fn join_seeded(&self, ja: &JoinApparatus<'a>, comms: &mut Comms, salad: &mut Salad<String>) {
+    fn join_seeded(&self, ja: &JoinApparatus, comms: &mut Comms, salad: &mut Salad<String>) {
         let mut result_facts: FactLSM<Forest<Terms>> = FactLSM::default();
 
         // Stable iteration order over the pattern; all disjuncts use the same pattern.
@@ -309,7 +315,7 @@ impl<'a> View<'a> {
     }
 }
 
-impl<'a> JoinDisjunct<'a> {
+impl JoinDisjunct {
     /// Term names corresponding to the columns `input_action` projects to. Computed
     /// from the plan's stage 0 terms — that's where the seed lands.
     fn seed_terms_for_action(&self) -> Vec<String> {
@@ -321,7 +327,7 @@ impl<'a> JoinDisjunct<'a> {
 
 /// Projects input salad onto `target_terms` by column position. Returns `None` if
 /// the salad is empty.
-fn canonicalize_salad<'a>(
+fn canonicalize_salad(
     salad: &Salad<String>,
     target_terms: &[String],
 ) -> Option<Salad<String>> {
@@ -346,7 +352,7 @@ fn canonicalize_salad<'a>(
 }
 
 /// Applies an Action to a salad, producing a new salad with the given `output_terms`.
-fn apply_action_to_salad<'a>(
+fn apply_action_to_salad(
     salad: &Salad<String>,
     action: &Action<Vec<u8>>,
     output_terms: Vec<String>,
@@ -372,10 +378,10 @@ fn apply_action_to_salad<'a>(
 /// This is the no-substitution counterpart to `compose_disjunct`'s `output_action`,
 /// used by `View::seed` (which materializes the full view without seeded
 /// pushdown — see `seed_disjuncts`).
-fn project_through_head<'a>(
+fn project_through_head(
     mut salad: Salad<String>,
     disjunct_head: &Atom,
-    use_site: &'a Atom,
+    use_site: &Atom,
 ) -> Salad<String> {
     assert_eq!(
         disjunct_head.terms.len(),
@@ -421,9 +427,9 @@ fn project_through_head<'a>(
 /// The runtime-ready result of composing a use-site request with one disjunct's head.
 ///
 /// Each field carries information for a different lifecycle:
-/// - `subst`: planning-time substitution (body var → use-site var or literal). Fed to
-///   `plan_rule_seeded`; consumed there to bias `build_atoms_map` and `base_actions_for`
-///   without rewriting the body's `Atom` structs.
+/// - `body`: the disjunct's body atoms with the composition's substitution applied
+///   in-place. `Action::from_body` and `plan_body` consume it natively — no separate
+///   subst channel needed downstream.
 /// - `seed`: pre-bound terms (use-site vars in pattern, in BTreeSet order). Fed to
 ///   `plan_rule_seeded` as its seed slice.
 /// - `need`: live disjunct vars that the use-site actually consumes (substituted-head
@@ -433,16 +439,30 @@ fn project_through_head<'a>(
 ///   by `plan_body`'s projection-target loop.
 /// - `input_action`: runtime Action applied to the input salad (columns in pattern
 ///   BTreeSet order) before passing to the disjunct. Filters by use-site/head
-///   constraints not pushable via subst; projects to seed columns.
+///   constraints not pushable via substitution; projects to seed columns.
 /// - `output_action`: runtime Action applied to the disjunct's output salad to
 ///   produce a use-site-shaped salad. Its `Ok(col)` projection entries index into
 ///   `need`-order (the disjunct salad's actual column order after projection-pushdown).
 struct DisjunctComposition {
-    subst: Subst,
+    body: Vec<Atom>,
     seed: Vec<String>,
     need: Vec<String>,
     input_action: Action<Vec<u8>>,
     output_action: Action<Vec<u8>>,
+}
+
+/// Walks each atom's terms, replacing any `Term::Var(name)` whose name appears in
+/// `subst` with the corresponding replacement term. Used by `compose_disjunct` to
+/// fold use-site constraints into the disjunct's body before planning.
+fn substitute_atoms(atoms: &[Atom], subst: &BTreeMap<String, Term>) -> Vec<Atom> {
+    atoms.iter().map(|atom| Atom {
+        name: atom.name.clone(),
+        anti: atom.anti,
+        terms: atom.terms.iter().map(|t| match t {
+            Term::Var(name) => subst.get(name).cloned().unwrap_or_else(|| t.clone()),
+            Term::Lit(_) => t.clone(),
+        }).collect(),
+    }).collect()
 }
 
 /// Composes a use-site request with one disjunct's head, producing the recipe for
@@ -461,11 +481,12 @@ fn compose_disjunct(
     pattern: &BTreeSet<String>,
     use_site: &Atom,
     disjunct_head: &Atom,
+    disjunct_body: &[Atom],
 ) -> Option<DisjunctComposition> {
     if use_site.terms.len() != disjunct_head.terms.len() { return None; }
 
     // Pass 1: build the substitution and collect input lit filters.
-    let mut subst: Subst = BTreeMap::new();
+    let mut subst: BTreeMap<String, Term> = BTreeMap::new();
     let mut input_lits: Vec<(String, Vec<u8>)> = Vec::new();
 
     for (us_term, dj_term) in use_site.terms.iter().zip(disjunct_head.terms.iter()) {
@@ -578,6 +599,7 @@ fn compose_disjunct(
         }
     }
 
-    Some(DisjunctComposition { subst, seed, need, input_action, output_action })
+    let body = substitute_atoms(disjunct_body, &subst);
+    Some(DisjunctComposition { body, seed, need, input_action, output_action })
 }
 

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -13,7 +13,7 @@ use crate::comms::Comms;
 use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
 use crate::rules::exec::Salad;
 use crate::rules::plan::{self, PlanAtom};
-use crate::rules::{ExecAtom, StageBoxes};
+use crate::rules::{ExecAtom, SeedExec, StageExec};
 use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
 /// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
@@ -44,12 +44,10 @@ pub struct SeedDisjunct {
     /// The disjunct's head atom (cloned from the defining rule). Used by `View::seed`
     /// to project results through the head's positional shape.
     pub head: Atom,
-    /// The plan for this disjunct's body (seed = body[0] in stable mode).
-    pub plan: plan::Plan<usize, String>,
     /// The pre-built seed atom whose `.seed()` produces the initial salad.
     pub seed: Box<dyn ExecAtom<String>>,
-    /// Pre-built non-seed atoms per stage, in plan order.
-    pub stages: Vec<StageBoxes>,
+    /// Pre-built per-stage executables (terms, output order, atoms), in plan order.
+    pub stages: Vec<StageExec>,
 }
 
 /// One disjunct of the apparatus used by `View::join` (the seeded-evaluation path):
@@ -68,10 +66,8 @@ pub struct JoinDisjunct {
     /// Projects disjunct columns to use-site var positions and injects literals
     /// at positions where the (substituted) disjunct head emits constants.
     pub output_action: Action<Vec<u8>>,
-    /// The seeded plan for the disjunct's body, planned with substitution applied.
-    pub plan: plan::Plan<usize, String>,
-    /// Pre-built atoms per stage, in plan order (one per atom in each stage).
-    pub stages: Vec<StageBoxes>,
+    /// Pre-built per-stage executables (terms, output order, atoms), in plan order.
+    pub stages: Vec<StageExec>,
 }
 
 /// Pre-built apparatus for `View::join` for one specific approach pattern.
@@ -123,7 +119,7 @@ impl View {
 
         let mut seed_disjuncts: Vec<SeedDisjunct> = Vec::with_capacity(defining.len());
         for rule in &defining {
-            let (plans, _loads, apparatus) = crate::rules::plan_and_build_with_fields(
+            let seed_execs = crate::rules::plan_and_build_with_fields(
                 facts, comms, decls, rules,
                 &rule.body[..], &rule.head[..],
                 true, None,
@@ -131,11 +127,13 @@ impl View {
             // Stable mode (delta_atoms = [0]) yields at most one entry; if empty
             // (the body's first atom can't act as a seed, e.g. a logic atom), the
             // disjunct contributes nothing and we skip it.
-            let plan = match plans.into_values().next() { Some(p) => p, None => continue };
-            let (seed, stages) = match apparatus.into_iter().next() { Some(a) => a, None => continue };
+            let SeedExec { seed, stages } = match seed_execs.into_iter().next() {
+                Some(s) => s,
+                None => continue,
+            };
             seed_disjuncts.push(SeedDisjunct {
                 head: rule.head[0].clone(),
-                plan, seed, stages,
+                seed, stages,
             });
         }
 
@@ -226,22 +224,24 @@ fn build_join_apparatus(
         // Ensure index actions for each load action in the seeded plan.
         crate::rules::ensure_actions_for_loads(facts, comms, decls, body, &loads);
 
-        // Build per-stage atoms. Pass `pattern_info: None` so any nested views
+        // Build per-stage executables. Pass `parent_plan: None` so any nested views
         // in the disjunct's body fall back to materialize for now.
-        let stages: Vec<StageBoxes> = plan.iter()
-            .map(|(atoms, _, _)| atoms.iter()
-                .map(|inner_load| crate::rules::build_atom(
-                    facts, comms, decls, rules,
-                    body, 0, *inner_load, &loads,
-                    None,
-                ))
-                .collect::<Vec<_>>())
+        let stages: Vec<StageExec> = plan.iter()
+            .map(|(atom_set, terms, output_order)| {
+                let atoms = atom_set.iter()
+                    .map(|inner_load| crate::rules::build_atom(
+                        facts, comms, decls, rules,
+                        body, 0, *inner_load, &loads,
+                        None,
+                    ))
+                    .collect();
+                StageExec { terms: terms.clone(), output_order: output_order.clone(), atoms }
+            })
             .collect();
 
         disjuncts.push(JoinDisjunct {
             input_action: comp.input_action,
             output_action: comp.output_action,
-            plan,
             stages,
         });
     }
@@ -256,7 +256,7 @@ impl ExecAtom<String> for View {
         let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
         for disjunct in &self.seed_disjuncts {
             let mut salad = disjunct.seed.seed(comms, recent);
-            crate::rules::run_wco_stages(comms, &mut salad, &disjunct.plan, &disjunct.stages, potato().clone());
+            crate::rules::run_wco_stages(comms, &mut salad, &disjunct.stages, potato().clone());
             let projected = project_through_head(salad, &disjunct.head, &self.use_site);
             result.facts.extend(projected.facts);
         }
@@ -313,7 +313,7 @@ impl View {
             );
             if disjunct_salad.facts.is_empty() { continue; }
             crate::rules::run_wco_stages(
-                comms, &mut disjunct_salad, &disjunct.plan, &disjunct.stages, potato().clone(),
+                comms, &mut disjunct_salad, &disjunct.stages, potato().clone(),
             );
             let projected = apply_action_to_salad(
                 &disjunct_salad, &disjunct.output_action, self.head_terms.clone(),
@@ -326,11 +326,11 @@ impl View {
 }
 
 impl JoinDisjunct {
-    /// Term names corresponding to the columns `input_action` projects to. Computed
-    /// from the plan's stage 0 terms — that's where the seed lands.
+    /// Term names corresponding to the columns `input_action` projects to. Reads
+    /// stage 0's term set — that's where the seed lands.
     fn seed_terms_for_action(&self) -> Vec<String> {
-        self.plan.first()
-            .map(|(_, terms, _)| terms.iter().cloned().collect())
+        self.stages.first()
+            .map(|stage| stage.terms.iter().cloned().collect())
             .unwrap_or_default()
     }
 }

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -34,7 +34,7 @@ pub struct ViewPlan<'a> {
 impl<'a> PlanAtom<&'a String> for ViewPlan<'a> {
     fn terms(&self) -> BTreeSet<&'a String> { self.head_terms.clone() }
     fn ground(&self, terms: &BTreeSet<&'a String>) -> BTreeSet<&'a String> {
-        self.head_terms.difference(terms).copied().collect()
+        self.head_terms.difference(terms).cloned().collect()
     }
 }
 
@@ -161,7 +161,7 @@ fn build_join_apparatus<'a>(
         body[plan_atom].terms.iter().filter_map(|t| t.as_var()).collect();
     for (i, (_, terms_to_intro, _)) in plan.iter().enumerate() {
         if i >= stage_idx { break; }
-        bound_at_stage.extend(terms_to_intro.iter().copied());
+        bound_at_stage.extend(terms_to_intro.iter().cloned());
     }
 
     let load_terms_set: BTreeSet<&'a String> =
@@ -178,11 +178,11 @@ fn build_join_apparatus<'a>(
     // by the time `join` is called.
     let pattern: BTreeSet<&'a String> =
         if stage_atoms.len() == 1 && stage_atoms.contains(&load_atom) {
-            load_terms_set.difference(&stage_terms_to_intro).copied().collect()
+            load_terms_set.difference(&stage_terms_to_intro).cloned().collect()
         } else {
             let mut all_bound = bound_at_stage.clone();
-            all_bound.extend(stage_terms_to_intro.iter().copied());
-            load_terms_set.intersection(&all_bound).copied().collect()
+            all_bound.extend(stage_terms_to_intro.iter().cloned());
+            load_terms_set.intersection(&all_bound).cloned().collect()
         };
 
     // Build per-disjunct join apparatus.
@@ -256,7 +256,7 @@ impl<'a> ExecAtom<&'a String> for View<'a> {
         // excluding any that this call is supposed to introduce.
         let bound_in_salad: BTreeSet<&'a String> = self.head_terms.iter()
             .filter(|t| salad.terms.contains(*t) && !added.contains(*t))
-            .copied()
+            .cloned()
             .collect();
 
         if let Some(ja) = self.join_apparatus.as_ref() {
@@ -282,7 +282,7 @@ impl<'a> View<'a> {
         let mut result_facts: FactLSM<Forest<Terms>> = FactLSM::default();
 
         // Stable iteration order over the pattern; all disjuncts use the same pattern.
-        let pattern_terms: Vec<&'a String> = ja.pattern.iter().copied().collect();
+        let pattern_terms: Vec<&'a String> = ja.pattern.iter().cloned().collect();
 
         // Canonicalize input salad to pattern-term order. Each disjunct's `input_action`
         // assumes columns are in this order.
@@ -314,7 +314,7 @@ impl<'a> JoinDisjunct<'a> {
     /// from the plan's stage 0 terms — that's where the seed lands.
     fn seed_terms_for_action(&self) -> Vec<&'a String> {
         self.plan.first()
-            .map(|(_, terms, _)| terms.iter().copied().collect())
+            .map(|(_, terms, _)| terms.iter().cloned().collect())
             .unwrap_or_default()
     }
 }
@@ -500,12 +500,12 @@ fn compose_disjunct<'a>(
 
     // Seed: all pattern vars (BTreeSet order). `plan_body` filters out vars unused
     // by the (substituted) body via its `init_terms` step.
-    let seed: Vec<&'a String> = pattern.iter().copied().collect();
+    let seed: Vec<&'a String> = pattern.iter().cloned().collect();
 
     // Build input_action. Assumes the input salad has been canonicalized to
     // pattern-term order (BTreeSet iteration). Filters by collected lits, projects
     // to the seed columns.
-    let pattern_terms: Vec<&'a String> = pattern.iter().copied().collect();
+    let pattern_terms: Vec<&'a String> = pattern.iter().cloned().collect();
     let mut input_action = Action::with_arity(pattern_terms.len());
     for (vu, ld) in &input_lits {
         let col = pattern_terms.iter().position(|t| *t == *vu)

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -13,7 +13,7 @@ use crate::comms::Comms;
 use crate::facts::{FactContainer, FactLSM, Forest, Relations, Terms};
 use crate::rules::exec::Salad;
 use crate::rules::plan::{self, PlanAtom};
-use crate::rules::{ExecAtom, SeedApparatus, StageBoxes};
+use crate::rules::{ExecAtom, StageBoxes};
 use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
 /// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
@@ -38,18 +38,23 @@ impl PlanAtom<String> for ViewPlan {
     }
 }
 
-/// One disjunct of the seed apparatus: cloned head atom plus its standard apparatus.
+/// One disjunct of the apparatus used by `View::seed` (the full-materialization path).
+/// Cloned head atom plus its planned execution.
 pub struct SeedDisjunct {
     /// The disjunct's head atom (cloned from the defining rule). Used by `View::seed`
     /// to project results through the head's positional shape.
     pub head: Atom,
-    pub plans: plan::Plans<usize, String>,
-    pub loads: plan::Loads<usize, String>,
-    pub apparatus: SeedApparatus,
+    /// The plan for this disjunct's body (seed = body[0] in stable mode).
+    pub plan: plan::Plan<usize, String>,
+    /// The pre-built seed atom whose `.seed()` produces the initial salad.
+    pub seed: Box<dyn ExecAtom<String>>,
+    /// Pre-built non-seed atoms per stage, in plan order.
+    pub stages: Vec<StageBoxes>,
 }
 
-/// One disjunct of the join apparatus: the seeded plan for the disjunct's body and
-/// the runtime Actions that translate between use-site and disjunct schemas.
+/// One disjunct of the apparatus used by `View::join` (the seeded-evaluation path):
+/// the seeded plan for the disjunct's body and the runtime Actions that translate
+/// between use-site and disjunct schemas.
 ///
 /// At runtime, evaluation is: canonicalize input salad to pattern order → apply
 /// `input_action` → run plan stages → apply `output_action` → use-site-shaped salad.
@@ -81,10 +86,12 @@ pub struct View {
     /// The use-site atom (cloned at build time). Used by `View::seed` to shape output.
     pub use_site: Atom,
     pub head_terms: Vec<String>,
-    /// Apparatus for `seed` (when view is itself the seed). Always present.
+    /// Per-disjunct apparatus consumed by `View::seed` (full materialization, used
+    /// when the view is itself the seed in a surrounding rule). Always present.
     pub seed_disjuncts: Vec<SeedDisjunct>,
-    /// Apparatus for `join` for a single pre-known approach pattern. Present when
-    /// the construction site identified a pattern via the parent plan.
+    /// Apparatus consumed by `View::join` (seeded evaluation, for one pre-known
+    /// approach pattern). Present when the construction site identified a pattern
+    /// via the parent plan.
     pub join_apparatus: Option<JoinApparatus>,
 }
 
@@ -116,14 +123,19 @@ impl View {
 
         let mut seed_disjuncts: Vec<SeedDisjunct> = Vec::with_capacity(defining.len());
         for rule in &defining {
-            let (plans, loads, apparatus) = crate::rules::plan_and_build_with_fields(
+            let (plans, _loads, apparatus) = crate::rules::plan_and_build_with_fields(
                 facts, comms, decls, rules,
                 &rule.body[..], &rule.head[..],
                 true, None,
             );
+            // Stable mode (delta_atoms = [0]) yields at most one entry; if empty
+            // (the body's first atom can't act as a seed, e.g. a logic atom), the
+            // disjunct contributes nothing and we skip it.
+            let plan = match plans.into_values().next() { Some(p) => p, None => continue };
+            let (seed, stages) = match apparatus.into_iter().next() { Some(a) => a, None => continue };
             seed_disjuncts.push(SeedDisjunct {
                 head: rule.head[0].clone(),
-                plans, loads, apparatus,
+                plan, seed, stages,
             });
         }
 
@@ -243,12 +255,10 @@ impl ExecAtom<String> for View {
     fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<String> {
         let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
         for disjunct in &self.seed_disjuncts {
-            for ((_plan_atom, plan), (driver, stages)) in disjunct.plans.iter().zip(&disjunct.apparatus) {
-                let mut salad = driver.seed(comms, recent);
-                crate::rules::run_wco_stages(comms, &mut salad, plan, stages, potato().clone());
-                let projected = project_through_head(salad, &disjunct.head, &self.use_site);
-                result.facts.extend(projected.facts);
-            }
+            let mut salad = disjunct.seed.seed(comms, recent);
+            crate::rules::run_wco_stages(comms, &mut salad, &disjunct.plan, &disjunct.stages, potato().clone());
+            let projected = project_through_head(salad, &disjunct.head, &self.use_site);
+            result.facts.extend(projected.facts);
         }
         result
     }

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -87,9 +87,7 @@ impl View {
     /// If `parent_plan` is provided (view used as a non-seed in a join), also
     /// pre-plans a join apparatus for the inferred approach pattern. Per-disjunct
     /// composition contradictions (lit-vs-lit mismatch, substitution conflict) drop
-    /// that disjunct from the apparatus; `View::join` falls back to materialize-and-
-    /// delegate when no `parent_plan` was available or the runtime pattern doesn't
-    /// match the apparatus pattern.
+    /// that disjunct from the apparatus.
     pub fn build(
         facts: &mut Relations,
         comms: &mut Comms,
@@ -256,27 +254,18 @@ impl ExecAtom<String> for View {
         // No-op: view atoms never propose values during the count protocol.
     }
 
-    fn join(&self, comms: &mut Comms, salad: &mut Salad<String>, added: &BTreeSet<String>, after: &[String]) {
-        // The call's approach pattern: which sum terms are bound in the input salad,
-        // excluding any that this call is supposed to introduce.
+    fn join(&self, comms: &mut Comms, salad: &mut Salad<String>, added: &BTreeSet<String>, _after: &[String]) {
+        let ja = self.join_apparatus.as_ref()
+            .expect("View::join: missing join_apparatus (only constructed for non-driver use)");
         let bound_in_salad: BTreeSet<String> = self.head_terms.iter()
             .filter(|t| salad.terms.contains(*t) && !added.contains(*t))
             .cloned()
             .collect();
-
-        if let Some(ja) = self.join_apparatus.as_ref() {
-            if ja.pattern == bound_in_salad {
-                self.join_seeded(ja, comms, salad);
-                return;
-            }
-        }
-
-        // Fallback: materialize the full sum and delegate to the data-atom join.
-        let materialized = self.seed(comms, false);
-        let facts: Vec<Forest<Terms>> = materialized.facts.into_iter().collect();
-        let temp: (Vec<Forest<Terms>>, Vec<String>, Option<Forest<Terms>>) =
-            (facts, materialized.terms, None);
-        temp.join(comms, salad, added, after);
+        assert_eq!(
+            ja.pattern, bound_in_salad,
+            "View::join: apparatus pattern does not match runtime bound-in-salad",
+        );
+        self.join_seeded(ja, comms, salad);
     }
 }
 
@@ -297,8 +286,14 @@ impl View {
         };
 
         for disjunct in &ja.disjuncts {
+            // The input salad enters the disjunct with stage 0's term set as its
+            // column names — that's where the seed lands per `Plan`'s stage 0
+            // semantics.
+            let seed_terms: Vec<String> = disjunct.stages.first()
+                .map(|stage| stage.terms.iter().cloned().collect())
+                .unwrap_or_default();
             let mut disjunct_salad = apply_action_to_salad(
-                &canonical, &disjunct.input_action, disjunct.seed_terms_for_action(),
+                &canonical, &disjunct.input_action, seed_terms,
             );
             if disjunct_salad.facts.is_empty() { continue; }
             crate::rules::run_wco_stages(comms, &mut disjunct_salad, &disjunct.stages);
@@ -309,16 +304,6 @@ impl View {
         }
 
         *salad = Salad::new(result_facts, self.head_terms.clone());
-    }
-}
-
-impl JoinDisjunct {
-    /// Term names corresponding to the columns `input_action` projects to. Reads
-    /// stage 0's term set — that's where the seed lands.
-    fn seed_terms_for_action(&self) -> Vec<String> {
-        self.stages.first()
-            .map(|stage| stage.terms.iter().cloned().collect())
-            .unwrap_or_default()
     }
 }
 

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -18,8 +18,8 @@ use crate::types::{Action, Atom, RelationDecl, Rule, Term};
 
 /// A `&'static String` placeholder used as the count-metadata column name in `wco_join`.
 ///
-/// Lives 'static so it can coerce to any `&'a String`. `wco_join` runs on salads
-/// whose term type is `&'a String` for an `'a` we don't own; a local `String`
+/// Lives 'static so it can coerce to any `String`. `wco_join` runs on salads
+/// whose term type is `String` for an `'a` we don't own; a local `String`
 /// declared inside `View::seed`/`View::join_seeded` wouldn't live long enough.
 fn potato() -> &'static String {
     static POTATO: OnceLock<String> = OnceLock::new();
@@ -27,13 +27,13 @@ fn potato() -> &'static String {
 }
 
 /// PlanAtom proxy for view references — no apparatus, just term info.
-pub struct ViewPlan<'a> {
-    pub head_terms: BTreeSet<&'a String>,
+pub struct ViewPlan {
+    pub head_terms: BTreeSet<String>,
 }
 
-impl<'a> PlanAtom<&'a String> for ViewPlan<'a> {
-    fn terms(&self) -> BTreeSet<&'a String> { self.head_terms.clone() }
-    fn ground(&self, terms: &BTreeSet<&'a String>) -> BTreeSet<&'a String> {
+impl PlanAtom<String> for ViewPlan {
+    fn terms(&self) -> BTreeSet<String> { self.head_terms.clone() }
+    fn ground(&self, terms: &BTreeSet<String>) -> BTreeSet<String> {
         self.head_terms.difference(terms).cloned().collect()
     }
 }
@@ -41,8 +41,8 @@ impl<'a> PlanAtom<&'a String> for ViewPlan<'a> {
 /// One disjunct of the seed apparatus: defining rule plus its standard apparatus.
 pub struct SeedDisjunct<'a> {
     pub rule: &'a Rule,
-    pub plans: plan::Plans<usize, &'a String>,
-    pub loads: plan::Loads<usize, &'a String>,
+    pub plans: plan::Plans<usize, String>,
+    pub loads: plan::Loads<usize, String>,
     pub apparatus: SeedApparatus<'a>,
 }
 
@@ -63,7 +63,7 @@ pub struct JoinDisjunct<'a> {
     /// at positions where the (substituted) disjunct head emits constants.
     pub output_action: Action<Vec<u8>>,
     /// The seeded plan for the disjunct's body, planned with substitution applied.
-    pub plan: plan::Plan<usize, &'a String>,
+    pub plan: plan::Plan<usize, String>,
     /// Pre-built atoms per stage, in plan order (one per atom in each stage).
     pub stages: Vec<StageBoxes<'a>>,
 }
@@ -71,14 +71,14 @@ pub struct JoinDisjunct<'a> {
 /// Pre-built apparatus for `View::join` for one specific approach pattern.
 pub struct JoinApparatus<'a> {
     /// The pre-bound subset of sum's terms (in use-site space).
-    pub pattern: BTreeSet<&'a String>,
+    pub pattern: BTreeSet<String>,
     pub disjuncts: Vec<JoinDisjunct<'a>>,
 }
 
 /// ExecAtom for a view reference.
 pub struct View<'a> {
     pub use_site: &'a Atom,
-    pub head_terms: Vec<&'a String>,
+    pub head_terms: Vec<String>,
     /// Apparatus for `seed` (when sum is itself the seed). Always present.
     pub seed_disjuncts: Vec<SeedDisjunct<'a>>,
     /// Apparatus for `join` for a single pre-known approach pattern. Present when
@@ -104,7 +104,7 @@ impl<'a> View<'a> {
         body: &'a [Atom],
         plan_atom: usize,
         load_atom: usize,
-        parent_plan: Option<&plan::Plan<usize, &'a String>>,
+        parent_plan: Option<&plan::Plan<usize, String>>,
     ) -> View<'a> {
         let view_name = body[load_atom].name.as_str();
         let defining: Vec<&'a Rule> = rules.iter()
@@ -123,7 +123,7 @@ impl<'a> View<'a> {
         }
 
         let use_site = &body[load_atom];
-        let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
+        let head_terms: Vec<String> = use_site.terms.iter().filter_map(|t| t.as_var().cloned()).collect();
 
         let join_apparatus = parent_plan.and_then(|plan| {
             build_join_apparatus(facts, comms, decls, rules, plan, body, plan_atom, load_atom, &defining, use_site)
@@ -144,7 +144,7 @@ fn build_join_apparatus<'a>(
     comms: &mut Comms,
     decls: &'a std::collections::BTreeMap<String, RelationDecl>,
     rules: &'a [(Rule, Vec<Duration>)],
-    plan: &plan::Plan<usize, &'a String>,
+    plan: &plan::Plan<usize, String>,
     body: &'a [Atom],
     plan_atom: usize,
     load_atom: usize,
@@ -157,26 +157,26 @@ fn build_join_apparatus<'a>(
 
     // Variables bound at the start of stage `stage_idx`: the seed's own terms plus
     // every prior stage's `terms_to_introduce`.
-    let mut bound_at_stage: BTreeSet<&'a String> =
-        body[plan_atom].terms.iter().filter_map(|t| t.as_var()).collect();
+    let mut bound_at_stage: BTreeSet<String> =
+        body[plan_atom].terms.iter().filter_map(|t| t.as_var().cloned()).collect();
     for (i, (_, terms_to_intro, _)) in plan.iter().enumerate() {
         if i >= stage_idx { break; }
         bound_at_stage.extend(terms_to_intro.iter().cloned());
     }
 
-    let load_terms_set: BTreeSet<&'a String> =
-        body[load_atom].terms.iter().filter_map(|t| t.as_var()).collect();
+    let load_terms_set: BTreeSet<String> =
+        body[load_atom].terms.iter().filter_map(|t| t.as_var().cloned()).collect();
 
     let (stage_atoms, stage_terms_field, _) = &plan[stage_idx];
     // Stage 0's `terms` field carries seed bindings (pre-bound), not introductions —
     // see `Plan` doc. For stages 1+, `terms` are the columns that stage introduces.
-    let stage_terms_to_intro: BTreeSet<&'a String> =
+    let stage_terms_to_intro: BTreeSet<String> =
         if stage_idx == 0 { BTreeSet::default() } else { stage_terms_field.clone() };
     // If sum is the sole atom in this stage, it acts as the proposer (count protocol
     // short-circuits to atom.join with terms). Pattern is sum's terms minus what this
     // stage introduces. Otherwise sum is a validator and all of sum's terms are bound
     // by the time `join` is called.
-    let pattern: BTreeSet<&'a String> =
+    let pattern: BTreeSet<String> =
         if stage_atoms.len() == 1 && stage_atoms.contains(&load_atom) {
             load_terms_set.difference(&stage_terms_to_intro).cloned().collect()
         } else {
@@ -230,16 +230,16 @@ fn build_join_apparatus<'a>(
     Some(JoinApparatus { pattern, disjuncts })
 }
 
-impl<'a> ExecAtom<&'a String> for View<'a> {
-    fn terms(&self) -> &[&'a String] { &self.head_terms[..] }
+impl<'a> ExecAtom<String> for View<'a> {
+    fn terms(&self) -> &[String] { &self.head_terms[..] }
 
-    fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<&'a String> {
+    fn seed(&self, comms: &mut Comms, recent: bool) -> Salad<String> {
         let mut result = Salad::new(FactLSM::default(), self.head_terms.clone());
         for disjunct in &self.seed_disjuncts {
             let disjunct_head = &disjunct.rule.head[0];
             for ((_plan_atom, plan), (driver, stages)) in disjunct.plans.iter().zip(&disjunct.apparatus) {
                 let mut salad = driver.seed(comms, recent);
-                crate::rules::run_wco_stages(comms, &mut salad, plan, stages, potato());
+                crate::rules::run_wco_stages(comms, &mut salad, plan, stages, potato().clone());
                 let projected = project_through_head(salad, disjunct_head, self.use_site);
                 result.facts.extend(projected.facts);
             }
@@ -247,14 +247,14 @@ impl<'a> ExecAtom<&'a String> for View<'a> {
         result
     }
 
-    fn count(&self, _comms: &mut Comms, _salad: &mut Salad<&'a String>, _added: &BTreeSet<&'a String>, _index: u8) {
+    fn count(&self, _comms: &mut Comms, _salad: &mut Salad<String>, _added: &BTreeSet<String>, _index: u8) {
         // No-op: view atoms never propose values during the count protocol.
     }
 
-    fn join(&self, comms: &mut Comms, salad: &mut Salad<&'a String>, added: &BTreeSet<&'a String>, after: &[&'a String]) {
+    fn join(&self, comms: &mut Comms, salad: &mut Salad<String>, added: &BTreeSet<String>, after: &[String]) {
         // The call's approach pattern: which sum terms are bound in the input salad,
         // excluding any that this call is supposed to introduce.
-        let bound_in_salad: BTreeSet<&'a String> = self.head_terms.iter()
+        let bound_in_salad: BTreeSet<String> = self.head_terms.iter()
             .filter(|t| salad.terms.contains(*t) && !added.contains(*t))
             .cloned()
             .collect();
@@ -269,7 +269,7 @@ impl<'a> ExecAtom<&'a String> for View<'a> {
         // Fallback: materialize the full sum and delegate to the data-atom join.
         let materialized = self.seed(comms, false);
         let facts: Vec<Forest<Terms>> = materialized.facts.into_iter().collect();
-        let temp: (Vec<Forest<Terms>>, Vec<&'a String>, Option<Forest<Terms>>) =
+        let temp: (Vec<Forest<Terms>>, Vec<String>, Option<Forest<Terms>>) =
             (facts, materialized.terms, None);
         temp.join(comms, salad, added, after);
     }
@@ -278,11 +278,11 @@ impl<'a> ExecAtom<&'a String> for View<'a> {
 impl<'a> View<'a> {
     /// Seeded-evaluation join: run each disjunct constrained by the input salad,
     /// project results back to use-site space, replace `salad` with the union.
-    fn join_seeded(&self, ja: &JoinApparatus<'a>, comms: &mut Comms, salad: &mut Salad<&'a String>) {
+    fn join_seeded(&self, ja: &JoinApparatus<'a>, comms: &mut Comms, salad: &mut Salad<String>) {
         let mut result_facts: FactLSM<Forest<Terms>> = FactLSM::default();
 
         // Stable iteration order over the pattern; all disjuncts use the same pattern.
-        let pattern_terms: Vec<&'a String> = ja.pattern.iter().cloned().collect();
+        let pattern_terms: Vec<String> = ja.pattern.iter().cloned().collect();
 
         // Canonicalize input salad to pattern-term order. Each disjunct's `input_action`
         // assumes columns are in this order.
@@ -297,7 +297,7 @@ impl<'a> View<'a> {
             );
             if disjunct_salad.facts.is_empty() { continue; }
             crate::rules::run_wco_stages(
-                comms, &mut disjunct_salad, &disjunct.plan, &disjunct.stages, potato(),
+                comms, &mut disjunct_salad, &disjunct.plan, &disjunct.stages, potato().clone(),
             );
             let projected = apply_action_to_salad(
                 &disjunct_salad, &disjunct.output_action, self.head_terms.clone(),
@@ -312,7 +312,7 @@ impl<'a> View<'a> {
 impl<'a> JoinDisjunct<'a> {
     /// Term names corresponding to the columns `input_action` projects to. Computed
     /// from the plan's stage 0 terms — that's where the seed lands.
-    fn seed_terms_for_action(&self) -> Vec<&'a String> {
+    fn seed_terms_for_action(&self) -> Vec<String> {
         self.plan.first()
             .map(|(_, terms, _)| terms.iter().cloned().collect())
             .unwrap_or_default()
@@ -322,9 +322,9 @@ impl<'a> JoinDisjunct<'a> {
 /// Projects input salad onto `target_terms` by column position. Returns `None` if
 /// the salad is empty.
 fn canonicalize_salad<'a>(
-    salad: &Salad<&'a String>,
-    target_terms: &[&'a String],
-) -> Option<Salad<&'a String>> {
+    salad: &Salad<String>,
+    target_terms: &[String],
+) -> Option<Salad<String>> {
     let projection: Vec<Result<usize, Vec<u8>>> = target_terms.iter().map(|t| {
         let col = salad.terms.iter().position(|s| *s == *t)
             .expect("target term not in salad");
@@ -347,10 +347,10 @@ fn canonicalize_salad<'a>(
 
 /// Applies an Action to a salad, producing a new salad with the given `output_terms`.
 fn apply_action_to_salad<'a>(
-    salad: &Salad<&'a String>,
+    salad: &Salad<String>,
     action: &Action<Vec<u8>>,
-    output_terms: Vec<&'a String>,
-) -> Salad<&'a String> {
+    output_terms: Vec<String>,
+) -> Salad<String> {
     let thresh = 200_000_000;
     let mut facts: FactLSM<Forest<Terms>> = FactLSM::default();
     for forest in salad.facts.contents() {
@@ -373,17 +373,17 @@ fn apply_action_to_salad<'a>(
 /// used by `View::seed` (which materializes the full view without seeded
 /// pushdown — see `seed_disjuncts`).
 fn project_through_head<'a>(
-    mut salad: Salad<&'a String>,
+    mut salad: Salad<String>,
     disjunct_head: &Atom,
     use_site: &'a Atom,
-) -> Salad<&'a String> {
+) -> Salad<String> {
     assert_eq!(
         disjunct_head.terms.len(),
         use_site.terms.len(),
         "Disjunct head and use-site atom must have the same arity"
     );
 
-    let head_terms: Vec<&'a String> = use_site.terms.iter().filter_map(|t| t.as_var()).collect();
+    let head_terms: Vec<String> = use_site.terms.iter().filter_map(|t| t.as_var().cloned()).collect();
     let mut action = Action::with_arity(salad.arity());
     for (us_term, dj_term) in use_site.terms.iter().zip(disjunct_head.terms.iter()) {
         match (us_term, dj_term) {
@@ -437,10 +437,10 @@ fn project_through_head<'a>(
 /// - `output_action`: runtime Action applied to the disjunct's output salad to
 ///   produce a use-site-shaped salad. Its `Ok(col)` projection entries index into
 ///   `need`-order (the disjunct salad's actual column order after projection-pushdown).
-struct DisjunctComposition<'a> {
-    subst: Subst<'a>,
-    seed: Vec<&'a String>,
-    need: Vec<&'a String>,
+struct DisjunctComposition {
+    subst: Subst,
+    seed: Vec<String>,
+    need: Vec<String>,
     input_action: Action<Vec<u8>>,
     output_action: Action<Vec<u8>>,
 }
@@ -457,16 +457,16 @@ struct DisjunctComposition<'a> {
 ///
 /// Returns `None` for arity mismatch, lit-vs-lit contradictions, or substitution
 /// conflicts.
-fn compose_disjunct<'a>(
-    pattern: &BTreeSet<&'a String>,
-    use_site: &'a Atom,
-    disjunct_head: &'a Atom,
-) -> Option<DisjunctComposition<'a>> {
+fn compose_disjunct(
+    pattern: &BTreeSet<String>,
+    use_site: &Atom,
+    disjunct_head: &Atom,
+) -> Option<DisjunctComposition> {
     if use_site.terms.len() != disjunct_head.terms.len() { return None; }
 
     // Pass 1: build the substitution and collect input lit filters.
-    let mut subst: Subst<'a> = BTreeMap::new();
-    let mut input_lits: Vec<(&'a String, &'a Vec<u8>)> = Vec::new();
+    let mut subst: Subst = BTreeMap::new();
+    let mut input_lits: Vec<(String, Vec<u8>)> = Vec::new();
 
     for (us_term, dj_term) in use_site.terms.iter().zip(disjunct_head.terms.iter()) {
         match (us_term, dj_term) {
@@ -475,12 +475,12 @@ fn compose_disjunct<'a>(
                 match subst.get(vd) {
                     Some(Term::Var(prev)) if prev != vu => return None,
                     Some(Term::Lit(_)) => return None,
-                    _ => { subst.insert(vd, us_term); }
+                    _ => { subst.insert(vd.clone(), us_term.clone()); }
                 }
             }
             (Term::Var(vu), Term::Lit(ld)) => {
                 if pattern.contains(vu) {
-                    input_lits.push((vu, ld));
+                    input_lits.push((vu.clone(), ld.clone()));
                 }
                 // Else: vu is not pre-bound; gets bound to ld at output via output_action.
             }
@@ -489,7 +489,7 @@ fn compose_disjunct<'a>(
                 match subst.get(vd) {
                     Some(Term::Lit(prev)) if prev != lu => return None,
                     Some(Term::Var(_)) => return None,
-                    _ => { subst.insert(vd, us_term); }
+                    _ => { subst.insert(vd.clone(), us_term.clone()); }
                 }
             }
             (Term::Lit(lu), Term::Lit(ld)) => {
@@ -500,12 +500,12 @@ fn compose_disjunct<'a>(
 
     // Seed: all pattern vars (BTreeSet order). `plan_body` filters out vars unused
     // by the (substituted) body via its `init_terms` step.
-    let seed: Vec<&'a String> = pattern.iter().cloned().collect();
+    let seed: Vec<String> = pattern.iter().cloned().collect();
 
     // Build input_action. Assumes the input salad has been canonicalized to
     // pattern-term order (BTreeSet iteration). Filters by collected lits, projects
     // to the seed columns.
-    let pattern_terms: Vec<&'a String> = pattern.iter().cloned().collect();
+    let pattern_terms: Vec<String> = pattern.iter().cloned().collect();
     let mut input_action = Action::with_arity(pattern_terms.len());
     for (vu, ld) in &input_lits {
         let col = pattern_terms.iter().position(|t| *t == *vu)
@@ -520,32 +520,32 @@ fn compose_disjunct<'a>(
     // Determine which substituted-head vars are *live* — referenced by some use-site
     // var position. Vars in the substituted head but not live are dead from the
     // use-site's perspective; `plan_body` will drop them in its last-stage projection.
-    let mut live: BTreeSet<&'a String> = BTreeSet::default();
+    let mut live: BTreeSet<String> = BTreeSet::default();
     for (i, us_term) in use_site.terms.iter().enumerate() {
         if let Term::Var(_) = us_term {
             if let Term::Var(vd) = &disjunct_head.terms[i] {
-                let effective: Option<&'a String> = match subst.get(vd) {
-                    Some(Term::Var(new_name)) => Some(new_name),
+                let effective: Option<String> = match subst.get(vd) {
+                    Some(Term::Var(new_name)) => Some(new_name.clone()),
                     Some(Term::Lit(_)) => None,
-                    None => Some(vd),
+                    None => Some(vd.clone()),
                 };
                 if let Some(n) = effective { live.insert(n); }
             }
         }
     }
     // `need`: substituted head's distinct vars in presentation order, filtered to live.
-    let need: Vec<&'a String> = {
-        let mut seen: BTreeSet<&'a String> = BTreeSet::default();
-        let mut out: Vec<&'a String> = Vec::new();
+    let need: Vec<String> = {
+        let mut seen: BTreeSet<String> = BTreeSet::default();
+        let mut out: Vec<String> = Vec::new();
         for t in disjunct_head.terms.iter() {
             if let Term::Var(name) = t {
-                let effective: Option<&'a String> = match subst.get(name) {
-                    Some(Term::Var(new_name)) => Some(new_name),
+                let effective: Option<String> = match subst.get(name) {
+                    Some(Term::Var(new_name)) => Some(new_name.clone()),
                     Some(Term::Lit(_)) => None,
-                    None => Some(name),
+                    None => Some(name.clone()),
                 };
                 if let Some(n) = effective {
-                    if live.contains(n) && seen.insert(n) { out.push(n); }
+                    if live.contains(&n) && seen.insert(n.clone()) { out.push(n); }
                 }
             }
         }
@@ -561,13 +561,13 @@ fn compose_disjunct<'a>(
             let emit: Result<usize, Vec<u8>> = match &disjunct_head.terms[i] {
                 Term::Var(vd) => match subst.get(vd) {
                     Some(Term::Var(new_name)) => {
-                        let col = need.iter().position(|t| *t as &String == new_name as &String)
+                        let col = need.iter().position(|t| t == new_name)
                             .expect("substituted var not in need");
                         Ok(col)
                     }
                     Some(Term::Lit(value)) => Err(value.clone()),
                     None => {
-                        let col = need.iter().position(|t| *t as &String == vd as &String)
+                        let col = need.iter().position(|t| t == vd)
                             .expect("disjunct head var not in need");
                         Ok(col)
                     }

--- a/src/rules/exec.rs
+++ b/src/rules/exec.rs
@@ -51,7 +51,7 @@ pub struct Salad<T> {
     pub terms: Vec<T>,
 }
 
-impl<T: Ord+Copy> Salad<T> {
+impl<T: Ord+Clone> Salad<T> {
     /// Constructs a new `Self` from facts and terms.
     pub fn new(facts: FactLSM<Forest<Terms>>, terms: Vec<T>) -> Self { Self { facts, terms } }
 
@@ -91,9 +91,9 @@ impl<T: Ord+Copy> Salad<T> {
 
         if !identity {
             if let Some(flattened) = salad.facts.flatten() {
-                salad.facts.extend(flattened.act_on(&Action::permutation(permutation.iter().copied()), thresh));
+                salad.facts.extend(flattened.act_on(&Action::permutation(permutation.iter().cloned()), thresh));
             }
-            salad.terms = permutation.iter().map(|i| salad.terms[*i]).collect::<Vec<_>>();
+            salad.terms = permutation.iter().map(|i| salad.terms[*i].clone()).collect::<Vec<_>>();
         }
 
         // Maybe necessary if `permutation` is `0 .. k` for k less than the input arity.
@@ -127,7 +127,7 @@ enum PermuteMode { Align, Prune }
 /// The `target` argument is the intended term order, which the output may be restricted to if appropriate.
 use crate::facts::{Forest, Terms};
 #[inline(never)]
-pub fn wco_join<T: Ord + Copy + std::fmt::Debug>(
+pub fn wco_join<T: Ord + Clone + std::fmt::Debug>(
     comms: &mut Comms,
     salad: &mut Salad<T>,
     terms: &BTreeSet<T>,
@@ -148,16 +148,16 @@ pub fn wco_join<T: Ord + Copy + std::fmt::Debug>(
     }
     else {
         // Multiple atoms will use worst-case optimal machinery, but we first sequester any columns not referenced by the atoms.
-        let shared = salad.terms.iter().filter(|t| atoms.iter().any(|a| a.terms().contains(t))).copied().collect::<Vec<_>>();
+        let shared = salad.terms.iter().filter(|t| atoms.iter().any(|a| a.terms().contains(t))).cloned().collect::<Vec<_>>();
         if salad.terms.len() != shared.len() {
-            salad.align_to(comms, shared.iter().copied());
+            salad.align_to(comms, shared.iter().cloned());
             let mut prefix = salad.clone();
             prefix.truncate(shared.len());
 
             let mut shared_target = shared.clone();
-            shared_target.extend(terms.iter().copied());
+            shared_target.extend(terms.iter().cloned());
             wco_join_inner(comms, &mut prefix, terms, atoms, potato, &shared_target);
-            prefix.align_to(comms, salad.terms[..shared.len()].iter().copied());
+            prefix.align_to(comms, salad.terms[..shared.len()].iter().cloned());
 
             // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
             assert!(shared.len() > 0 || comms.peers() == 1);
@@ -166,8 +166,8 @@ pub fn wco_join<T: Ord + Copy + std::fmt::Debug>(
             let conduit = comms.conduit();
             if let Some(facts) = salad.facts.flatten() {
                 let mut crossed_terms = salad.terms.clone();
-                crossed_terms.extend(salad.terms[..shared.len()].iter().copied());
-                crossed_terms.extend(terms.iter().copied());
+                crossed_terms.extend(salad.terms[..shared.len()].iter().cloned());
+                crossed_terms.extend(terms.iter().cloned());
                 let projection = target.iter().map(|t| crossed_terms.iter().position(|t2| t == t2).unwrap()).collect::<Vec<_>>();
                 salad.facts = facts.join_many(prefix.facts.contents(), shared.len(), &projection[..], conduit);
             }
@@ -180,7 +180,7 @@ pub fn wco_join<T: Ord + Copy + std::fmt::Debug>(
         else { wco_join_inner(comms, salad, terms, atoms, potato, target) }
     }
 
-    salad.prune_to(comms, target.iter().copied());
+    salad.prune_to(comms, target.iter().cloned());
 }
 
 /// Inner workings of the worst-case optimal join step.
@@ -188,7 +188,7 @@ pub fn wco_join<T: Ord + Copy + std::fmt::Debug>(
 /// This logic happens only after the preparatory logic above, and probably oughtn't be called by itself.
 /// It unambiguously applies per-atom counting, sharding, proposals, and validation.
 #[inline(never)]
-fn wco_join_inner<T: Ord + Copy + std::fmt::Debug>(
+fn wco_join_inner<T: Ord + Clone + std::fmt::Debug>(
     comms: &mut Comms,
     salad: &mut Salad<T>,
     terms: &BTreeSet<T>,
@@ -251,9 +251,9 @@ fn wco_join_inner<T: Ord + Copy + std::fmt::Debug>(
 
         // Look forward to the terms of the next atom we'll semijoin with.
         let next_terms = atoms[if shard_index == 0 { 1 } else { 0 }].terms();
-        let mut after = Vec::default();
-        after.extend(next_terms.iter().filter(|t| salad.terms.contains(t) || terms.contains(t)));
-        after.extend(salad.terms.iter().filter(|t| !next_terms.contains(t)));
+        let mut after: Vec<T> = Vec::default();
+        after.extend(next_terms.iter().filter(|t| salad.terms.contains(t) || terms.contains(t)).cloned());
+        after.extend(salad.terms.iter().filter(|t| !next_terms.contains(t)).cloned());
         other.join(comms, &mut shard, terms, &after);
 
         // semijoin with other atoms.
@@ -264,7 +264,7 @@ fn wco_join_inner<T: Ord + Copy + std::fmt::Debug>(
         }
 
         // Put in common layout (`target`) then merge.
-        shard.prune_to(comms, target.iter().copied());
+        shard.prune_to(comms, target.iter().cloned());
         salad.extend(shard.facts);
     }
 }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -64,8 +64,27 @@ pub(crate) fn build_atom(
     }
 }
 
-/// One plan stage's pre-built non-seed atoms, in plan order.
-pub type StageBoxes = Vec<Box<dyn exec::ExecAtom<String>>>;
+/// One plan stage's runtime form: which terms to introduce, the post-stage column
+/// order, and the pre-built atoms to apply. Built from a `Plan` stage's
+/// `(atom_set, terms, output_order)` triple — the atom indices are consumed at
+/// build time and the resulting `atoms` are the executable form.
+pub struct StageExec {
+    /// Columns this stage introduces (per `Plan`'s stage `terms` set). Stage 0
+    /// carries the seed-relevant pre-bindings; `run_wco_stages` overrides to
+    /// empty there.
+    pub terms: std::collections::BTreeSet<String>,
+    /// Salad column order to leave behind after this stage.
+    pub output_order: Vec<String>,
+    /// Pre-built atoms participating in this stage, in plan order.
+    pub atoms: Vec<Box<dyn exec::ExecAtom<String>>>,
+}
+
+/// Pre-built apparatus for one seed of a rule: the seed atom (whose `.seed()`
+/// produces the initial salad) followed by the per-stage executables.
+pub struct SeedExec {
+    pub seed: Box<dyn exec::ExecAtom<String>>,
+    pub stages: Vec<StageExec>,
+}
 
 /// Plans a rule body and pre-builds the boxed atoms for every (seed, stage).
 ///
@@ -73,6 +92,11 @@ pub type StageBoxes = Vec<Box<dyn exec::ExecAtom<String>>>;
 /// invoke this with the same field borrows. Callers split a `&mut State` into its
 /// fields and pass them through. `rules` is the State's rule list, used to look up
 /// views' defining rules during view-atom construction.
+///
+/// Returns one `SeedExec` per planned seed atom. The intermediate `Plans`/`Loads`
+/// from `plan::plan_rule` are consumed internally — their structural information
+/// (per-stage terms and output orders) is baked into each `StageExec`, and the
+/// load actions are used during atom construction and then dropped.
 pub fn plan_and_build_with_fields(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
@@ -82,11 +106,7 @@ pub fn plan_and_build_with_fields(
     head: &[Atom],
     stable: bool,
     active_relations: Option<&std::collections::BTreeSet<&str>>,
-) -> (
-    plan::Plans<usize, String>,
-    plan::Loads<usize, String>,
-    Vec<(Box<dyn exec::ExecAtom<String>>, Vec<StageBoxes>)>,
-) {
+) -> Vec<SeedExec> {
     // Body atoms that should take a turn as the source of novelty this round.
     // In `stable` mode only the first body atom drives; in incremental mode every
     // atom takes a turn, optionally restricted to those whose relation has recent
@@ -105,23 +125,29 @@ pub fn plan_and_build_with_fields(
     for (plan_atom, _plan) in plans.iter() {
         ensure_actions_for_loads(facts, comms, decls, body, &loads[plan_atom]);
     }
-    // Pre-build the seed atom and all non-seed stage atoms per planned seed.
-    // Pre-building all seeds (rather than building them inline during execution)
-    // means each seed sees the round's input state, not facts an earlier seed
-    // committed mid-loop — keeping semi-naive's "this round vs. next round" line clean.
-    let apparatus = plans.iter()
+    // Pre-build the seed atom and per-stage executables for each planned seed.
+    // Pre-building (rather than building inline during execution) means each seed
+    // sees the round's input state, not facts an earlier seed committed mid-loop —
+    // keeping semi-naive's "this round vs. next round" line clean.
+    plans.iter()
         .map(|(plan_atom, plan)| {
             let plan_loads = &loads[plan_atom];
             let seed = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
-            let stages: Vec<StageBoxes> = plan.iter()
-                .map(|(atoms, _, _)| atoms.iter()
-                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan)))
-                    .collect::<Vec<_>>())
+            let stages: Vec<StageExec> = plan.iter()
+                .map(|(atom_set, terms, output_order)| {
+                    let atoms = atom_set.iter()
+                        .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan)))
+                        .collect();
+                    StageExec {
+                        terms: terms.clone(),
+                        output_order: output_order.clone(),
+                        atoms,
+                    }
+                })
                 .collect();
-            (seed, stages)
+            SeedExec { seed, stages }
         })
-        .collect();
-    (plans, loads, apparatus)
+        .collect()
 }
 
 impl crate::types::State {
@@ -143,16 +169,16 @@ impl crate::types::State {
         let decls = &self.decls;
         let rules = &self.rules[..];
 
-        let (plans, _loads, apparatus) = plan_and_build_with_fields(facts, comms, decls, rules, body, head, stable, active_relations);
+        let seed_execs = plan_and_build_with_fields(facts, comms, decls, rules, body, head, stable, active_relations);
 
         let potato = ".potato".to_string();
 
         // Per seed: seed → wco_join stages → emit head facts.
         // Seed atoms are pre-built, so each seed sees the round's input state
         // rather than facts that earlier seeds may have committed.
-        for ((_plan_atom, plan), (seed, stages_boxed)) in plans.iter().zip(apparatus) {
+        for SeedExec { seed, stages } in seed_execs {
             let mut salad = seed.seed(comms, !stable);
-            run_wco_stages(comms, &mut salad, plan, &stages_boxed, potato.clone());
+            run_wco_stages(comms, &mut salad, &stages, potato.clone());
             emit_head_facts(facts, comms, head, salad);
         }
     }
@@ -211,11 +237,12 @@ pub fn ensure_actions_for_loads(
     }
 }
 
-/// Runs the wco_join stages of a plan against a salad, mutating the salad in place.
+/// Runs the wco_join stages against a salad, mutating the salad in place.
 ///
-/// The single shared loop pattern used by `State::implement`, `Sum::seed`, and
-/// `Sum::join_seeded`. Each stage's `(terms, atoms, order)` triple feeds one
-/// `wco_join` call; `potato` is the column-name placeholder for count metadata.
+/// The single shared loop pattern used by `State::implement`, `View::seed`, and
+/// `View::join_seeded`. Each `StageExec` (with its terms, output order, and atoms)
+/// feeds one `wco_join` call; `potato` is the column-name placeholder for count
+/// metadata.
 ///
 /// Stage 0 is special: its `terms` document the seed's pre-bound bindings (already
 /// present in `salad`), not new columns to introduce. We pass an empty `terms` set so
@@ -225,14 +252,13 @@ pub fn ensure_actions_for_loads(
 pub fn run_wco_stages(
     comms: &mut crate::comms::Comms,
     salad: &mut exec::Salad<String>,
-    plan: &plan::Plan<usize, String>,
-    stages: &[StageBoxes],
+    stages: &[StageExec],
     potato: String,
 ) {
     let empty: std::collections::BTreeSet<String> = std::collections::BTreeSet::default();
-    for (i, ((_, terms, order), atoms)) in plan.iter().zip(stages.iter()).enumerate() {
-        let stage_terms = if i == 0 { &empty } else { terms };
-        exec::wco_join(comms, salad, stage_terms, atoms, potato.clone(), &order[..]);
+    for (i, stage) in stages.iter().enumerate() {
+        let stage_terms = if i == 0 { &empty } else { &stage.terms };
+        exec::wco_join(comms, salad, stage_terms, &stage.atoms, potato.clone(), &stage.output_order[..]);
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -34,20 +34,19 @@ pub use exec::ExecAtom;
 /// `parent_plan` is the surrounding rule's plan for this seed, threaded through so
 /// view atoms can compute their approach pattern from where they appear. `None`
 /// means the atom is itself the seed (no surrounding plan to inspect).
-pub(crate) fn build_atom<'a>(
+pub(crate) fn build_atom(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-    rules: &'a [(Rule, Vec<std::time::Duration>)],
-    body: &'a [Atom],
+    decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    rules: &[(Rule, Vec<std::time::Duration>)],
+    body: &[Atom],
     plan_atom: usize,
     load_atom: usize,
     loads: &std::collections::BTreeMap<usize, plan::Load<String>>,
     parent_plan: Option<&plan::Plan<usize, String>>,
-    subst: &plan::Subst,
-) -> Box<dyn exec::ExecAtom<String> + 'a> {
+) -> Box<dyn exec::ExecAtom<String>> {
     use crate::rules::atoms;
-    if let Some(logic) = atoms::logic::resolve_with_subst(&body[load_atom], subst) {
+    if let Some(logic) = atoms::logic::resolve(&body[load_atom]) {
         Box::new(logic)
     } else if decls.get(body[load_atom].name.as_str()).map_or(false, |d| d.view) {
         Box::new(atoms::view::View::build(
@@ -66,14 +65,14 @@ pub(crate) fn build_atom<'a>(
 }
 
 /// One plan stage's pre-built non-seed atoms, in plan order.
-pub type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<String> + 'a>>;
+pub type StageBoxes = Vec<Box<dyn exec::ExecAtom<String>>>;
 
 /// One seed's pre-built apparatus: the seed atom (whose `.seed()` produces the initial
 /// salad) and the per-stage non-seed atoms (used for `wco_join`).
-type SeedWork<'a> = (Box<dyn exec::ExecAtom<String> + 'a>, Vec<StageBoxes<'a>>);
+type SeedWork = (Box<dyn exec::ExecAtom<String>>, Vec<StageBoxes>);
 
 /// All seeds' apparatus, parallel to `Plans` iteration order.
-type SeedApparatus<'a> = Vec<SeedWork<'a>>;
+type SeedApparatus = Vec<SeedWork>;
 
 /// Plans a rule body and pre-builds the boxed atoms for every (seed, stage).
 ///
@@ -81,19 +80,19 @@ type SeedApparatus<'a> = Vec<SeedWork<'a>>;
 /// invoke this with the same field borrows. Callers split a `&mut State` into its
 /// fields and pass them through. `rules` is the State's rule list, used to look up
 /// views' defining rules during view-atom construction.
-pub fn plan_and_build_with_fields<'a>(
+pub fn plan_and_build_with_fields(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-    rules: &'a [(Rule, Vec<std::time::Duration>)],
-    body: &'a [Atom],
-    head: &'a [Atom],
+    decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    rules: &[(Rule, Vec<std::time::Duration>)],
+    body: &[Atom],
+    head: &[Atom],
     stable: bool,
     active_relations: Option<&std::collections::BTreeSet<&str>>,
 ) -> (
     plan::Plans<usize, String>,
     plan::Loads<usize, String>,
-    SeedApparatus<'a>,
+    SeedApparatus,
 ) {
     // Body atoms that should take a turn as the source of novelty this round.
     // In `stable` mode only the first body atom drives; in incremental mode every
@@ -117,14 +116,13 @@ pub fn plan_and_build_with_fields<'a>(
     // Pre-building all seeds (rather than building them inline during execution)
     // means each seed sees the round's input state, not facts an earlier seed
     // committed mid-loop — keeping semi-naive's "this round vs. next round" line clean.
-    let apparatus: SeedApparatus<'a> = plans.iter()
+    let apparatus: SeedApparatus = plans.iter()
         .map(|(plan_atom, plan)| {
             let plan_loads = &loads[plan_atom];
-            let empty_subst = plan::Subst::new();
-            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None, &empty_subst);
-            let stages: Vec<StageBoxes<'a>> = plan.iter()
+            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
+            let stages: Vec<StageBoxes> = plan.iter()
                 .map(|(atoms, _, _)| atoms.iter()
-                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan), &empty_subst))
+                    .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan)))
                     .collect::<Vec<_>>())
                 .collect();
             (driver, stages)
@@ -170,7 +168,7 @@ impl crate::types::State {
 /// Projects `salad` through each head atom and extends the corresponding relation.
 ///
 /// Free function so it can coexist with an outstanding apparatus borrow on `decls`.
-fn emit_head_facts<'a>(
+fn emit_head_facts(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
     head: &[Atom],
@@ -203,11 +201,11 @@ fn emit_head_facts<'a>(
 
 /// Ensures index actions exist for every non-logic, non-view atom referenced by the
 /// loads. This prepares the relations to serve queries in the orders the plan needs.
-pub fn ensure_actions_for_loads<'a>(
+pub fn ensure_actions_for_loads(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
     decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
-    body: &'a [Atom],
+    body: &[Atom],
     loads: &std::collections::BTreeMap<usize, plan::Load<String>>,
 ) {
     for (load_atom, (action, _)) in loads.iter() {
@@ -231,11 +229,11 @@ pub fn ensure_actions_for_loads<'a>(
 /// `wco_join` semijoins against `init_atoms` instead of routing through
 /// `wco_join_inner` and trying to re-introduce already-bound columns. Stages 1+
 /// follow the usual interpretation of `terms` as the new columns to extend with.
-pub fn run_wco_stages<'a>(
+pub fn run_wco_stages(
     comms: &mut crate::comms::Comms,
     salad: &mut exec::Salad<String>,
     plan: &plan::Plan<usize, String>,
-    stages: &[StageBoxes<'a>],
+    stages: &[StageBoxes],
     potato: String,
 ) {
     let empty: std::collections::BTreeSet<String> = std::collections::BTreeSet::default();

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -171,14 +171,12 @@ impl crate::types::State {
 
         let seed_execs = plan_and_build_with_fields(facts, comms, decls, rules, body, head, stable, active_relations);
 
-        let potato = ".potato".to_string();
-
         // Per seed: seed → wco_join stages → emit head facts.
         // Seed atoms are pre-built, so each seed sees the round's input state
         // rather than facts that earlier seeds may have committed.
         for SeedExec { seed, stages } in seed_execs {
             let mut salad = seed.seed(comms, !stable);
-            run_wco_stages(comms, &mut salad, &stages, potato.clone());
+            run_wco_stages(comms, &mut salad, &stages);
             emit_head_facts(facts, comms, head, salad);
         }
     }
@@ -253,9 +251,9 @@ pub fn run_wco_stages(
     comms: &mut crate::comms::Comms,
     salad: &mut exec::Salad<String>,
     stages: &[StageExec],
-    potato: String,
 ) {
     let empty: std::collections::BTreeSet<String> = std::collections::BTreeSet::default();
+    let potato = ".potato".to_string();
     for (i, stage) in stages.iter().enumerate() {
         let stage_terms = if i == 0 { &empty } else { &stage.terms };
         exec::wco_join(comms, salad, stage_terms, &stage.atoms, potato.clone(), &stage.output_order[..]);

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -42,10 +42,10 @@ pub(crate) fn build_atom<'a>(
     body: &'a [Atom],
     plan_atom: usize,
     load_atom: usize,
-    loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
-    parent_plan: Option<&plan::Plan<usize, &'a String>>,
-    subst: &plan::Subst<'a>,
-) -> Box<dyn exec::ExecAtom<&'a String> + 'a> {
+    loads: &std::collections::BTreeMap<usize, plan::Load<String>>,
+    parent_plan: Option<&plan::Plan<usize, String>>,
+    subst: &plan::Subst,
+) -> Box<dyn exec::ExecAtom<String> + 'a> {
     use crate::rules::atoms;
     if let Some(logic) = atoms::logic::resolve_with_subst(&body[load_atom], subst) {
         Box::new(logic)
@@ -59,18 +59,18 @@ pub(crate) fn build_atom<'a>(
         let to_chain = if load_atom >= plan_atom { other.recent.as_ref() } else { None };
         let other_facts: Vec<Forest<Terms>> = other.stable.contents().chain(to_chain).cloned().collect();
         let other_recent: Option<Forest<Terms>> = if plan_atom == load_atom { other.recent.clone() } else { None };
-        let owned_terms: Vec<&'a String> = load_terms.clone();
+        let owned_terms: Vec<String> = load_terms.clone();
         if body[load_atom].anti { Box::new(atoms::anti::Anti((other_facts, owned_terms))) }
         else                    { Box::new((other_facts, owned_terms, other_recent)) }
     }
 }
 
 /// One plan stage's pre-built non-seed atoms, in plan order.
-pub type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<&'a String> + 'a>>;
+pub type StageBoxes<'a> = Vec<Box<dyn exec::ExecAtom<String> + 'a>>;
 
 /// One seed's pre-built apparatus: the seed atom (whose `.seed()` produces the initial
 /// salad) and the per-stage non-seed atoms (used for `wco_join`).
-type SeedWork<'a> = (Box<dyn exec::ExecAtom<&'a String> + 'a>, Vec<StageBoxes<'a>>);
+type SeedWork<'a> = (Box<dyn exec::ExecAtom<String> + 'a>, Vec<StageBoxes<'a>>);
 
 /// All seeds' apparatus, parallel to `Plans` iteration order.
 type SeedApparatus<'a> = Vec<SeedWork<'a>>;
@@ -91,8 +91,8 @@ pub fn plan_and_build_with_fields<'a>(
     stable: bool,
     active_relations: Option<&std::collections::BTreeSet<&str>>,
 ) -> (
-    plan::Plans<usize, &'a String>,
-    plan::Loads<usize, &'a String>,
+    plan::Plans<usize, String>,
+    plan::Loads<usize, String>,
     SeedApparatus<'a>,
 ) {
     // Body atoms that should take a turn as the source of novelty this round.
@@ -161,7 +161,7 @@ impl crate::types::State {
         // rather than facts that earlier seeds may have committed.
         for ((_plan_atom, plan), (driver, stages_boxed)) in plans.iter().zip(apparatus) {
             let mut salad = driver.seed(comms, !stable);
-            run_wco_stages(comms, &mut salad, plan, &stages_boxed, &potato);
+            run_wco_stages(comms, &mut salad, plan, &stages_boxed, potato.clone());
             emit_head_facts(facts, comms, head, salad);
         }
     }
@@ -174,7 +174,7 @@ fn emit_head_facts<'a>(
     facts: &mut Relations,
     comms: &mut crate::comms::Comms,
     head: &[Atom],
-    mut salad: crate::rules::exec::Salad<&'a String>,
+    mut salad: crate::rules::exec::Salad<String>,
 ) {
     let exact_match = head.iter().position(|a| {
         a.terms.len() == salad.arity() &&
@@ -185,7 +185,7 @@ fn emit_head_facts<'a>(
     for (_, atom) in head.iter().enumerate().filter(|(pos,_)| Some(*pos) != exact_match) {
         let mut action = Action::with_arity(salad.arity());
         action.projection = atom.terms.iter().map(|t| match t {
-            Term::Var(name) => Ok(salad.terms.iter().position(|t2| t2 == &name).expect(format!("Failed to find {:?} in {:?}", name, salad.terms).as_str())),
+            Term::Var(name) => Ok(salad.terms.iter().position(|t2| t2 == name).expect(format!("Failed to find {:?} in {:?}", name, salad.terms).as_str())),
             Term::Lit(data) => Err(data.clone()),
         }).collect();
         if let Some(delta) = salad.facts.flatten() {
@@ -208,7 +208,7 @@ pub fn ensure_actions_for_loads<'a>(
     comms: &mut crate::comms::Comms,
     decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
     body: &'a [Atom],
-    loads: &std::collections::BTreeMap<usize, plan::Load<&'a String>>,
+    loads: &std::collections::BTreeMap<usize, plan::Load<String>>,
 ) {
     for (load_atom, (action, _)) in loads.iter() {
         let name = body[*load_atom].name.as_str();
@@ -233,14 +233,15 @@ pub fn ensure_actions_for_loads<'a>(
 /// follow the usual interpretation of `terms` as the new columns to extend with.
 pub fn run_wco_stages<'a>(
     comms: &mut crate::comms::Comms,
-    salad: &mut exec::Salad<&'a String>,
-    plan: &plan::Plan<usize, &'a String>,
+    salad: &mut exec::Salad<String>,
+    plan: &plan::Plan<usize, String>,
     stages: &[StageBoxes<'a>],
-    potato: &'a String,
+    potato: String,
 ) {
+    let empty: std::collections::BTreeSet<String> = std::collections::BTreeSet::default();
     for (i, ((_, terms, order), atoms)) in plan.iter().zip(stages.iter()).enumerate() {
-        let stage_terms = if i == 0 { &Default::default() } else { terms };
-        exec::wco_join(comms, salad, stage_terms, atoms, potato, &order[..]);
+        let stage_terms = if i == 0 { &empty } else { terms };
+        exec::wco_join(comms, salad, stage_terms, atoms, potato.clone(), &order[..]);
     }
 }
 

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -67,13 +67,6 @@ pub(crate) fn build_atom(
 /// One plan stage's pre-built non-seed atoms, in plan order.
 pub type StageBoxes = Vec<Box<dyn exec::ExecAtom<String>>>;
 
-/// One seed's pre-built apparatus: the seed atom (whose `.seed()` produces the initial
-/// salad) and the per-stage non-seed atoms (used for `wco_join`).
-type SeedWork = (Box<dyn exec::ExecAtom<String>>, Vec<StageBoxes>);
-
-/// All seeds' apparatus, parallel to `Plans` iteration order.
-type SeedApparatus = Vec<SeedWork>;
-
 /// Plans a rule body and pre-builds the boxed atoms for every (seed, stage).
 ///
 /// Lives as a free function (not a method) because view references recursively
@@ -92,7 +85,7 @@ pub fn plan_and_build_with_fields(
 ) -> (
     plan::Plans<usize, String>,
     plan::Loads<usize, String>,
-    SeedApparatus,
+    Vec<(Box<dyn exec::ExecAtom<String>>, Vec<StageBoxes>)>,
 ) {
     // Body atoms that should take a turn as the source of novelty this round.
     // In `stable` mode only the first body atom drives; in incremental mode every
@@ -116,16 +109,16 @@ pub fn plan_and_build_with_fields(
     // Pre-building all seeds (rather than building them inline during execution)
     // means each seed sees the round's input state, not facts an earlier seed
     // committed mid-loop — keeping semi-naive's "this round vs. next round" line clean.
-    let apparatus: SeedApparatus = plans.iter()
+    let apparatus = plans.iter()
         .map(|(plan_atom, plan)| {
             let plan_loads = &loads[plan_atom];
-            let driver = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
+            let seed = build_atom(facts, comms, decls, rules, body, *plan_atom, *plan_atom, plan_loads, None);
             let stages: Vec<StageBoxes> = plan.iter()
                 .map(|(atoms, _, _)| atoms.iter()
                     .map(|load_atom| build_atom(facts, comms, decls, rules, body, *plan_atom, *load_atom, plan_loads, Some(plan)))
                     .collect::<Vec<_>>())
                 .collect();
-            (driver, stages)
+            (seed, stages)
         })
         .collect();
     (plans, loads, apparatus)
@@ -157,8 +150,8 @@ impl crate::types::State {
         // Per seed: seed → wco_join stages → emit head facts.
         // Seed atoms are pre-built, so each seed sees the round's input state
         // rather than facts that earlier seeds may have committed.
-        for ((_plan_atom, plan), (driver, stages_boxed)) in plans.iter().zip(apparatus) {
-            let mut salad = driver.seed(comms, !stable);
+        for ((_plan_atom, plan), (seed, stages_boxed)) in plans.iter().zip(apparatus) {
+            let mut salad = seed.seed(comms, !stable);
             run_wco_stages(comms, &mut salad, plan, &stages_boxed, potato.clone());
             emit_head_facts(facts, comms, head, salad);
         }

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -191,23 +191,23 @@ fn seed_load<'a>(
 ///
 /// For each body atom, loads the atom's terms in the order the plan binds them.
 /// This order aims to minimize the number of distinct term orders to maintain.
-fn body_load<'a, A: Ord + Copy, T: Ord + Copy>(
+fn body_load<'a, A: Ord + Copy, T: Ord + Clone>(
     plan: &Plan<A, T>,
     body: &BTreeMap<A, Box<dyn PlanAtom<T> + 'a>>,
     base_actions: &BTreeMap<A, Action<Vec<u8>>>,
 ) -> BTreeMap<A, Load<T>> {
 
     // Term introduction order: walk stages, take each stage's new terms.
-    let mut all_terms = BTreeSet::default();
-    let mut in_order = Vec::default();
+    let mut all_terms: BTreeSet<T> = BTreeSet::default();
+    let mut in_order: Vec<T> = Vec::default();
     for (_atoms, terms, _out_order) in plan.iter() {
-        in_order.extend(terms.difference(&all_terms));
-        all_terms.extend(terms.iter().copied());
+        in_order.extend(terms.difference(&all_terms).cloned());
+        all_terms.extend(terms.iter().cloned());
     }
 
     body.iter().map(|(load_atom, boxed)| {
         let atom_terms = boxed.terms();
-        let load_terms: Vec<T> = in_order.iter().filter(|t| atom_terms.contains(t)).copied().collect();
+        let load_terms: Vec<T> = in_order.iter().filter(|t| atom_terms.contains(t)).cloned().collect();
         let mut action = base_actions[load_atom].clone();
         action.projection = in_order.iter()
             .flat_map(|t1| atom_terms.iter().position(|t2| t1 == t2))
@@ -272,7 +272,7 @@ pub fn plan_rule_seeded<'a>(
 /// semijoin without re-permuting the salad. The planner doesn't consult it today, but
 /// the order is meaningful — callers should pass terms in the order their salad's
 /// columns are arranged.
-pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
+pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
     seed: &[T],
     body: &BTreeMap<A, Box<dyn PlanAtom<T> + '_>>,
     need: &[T],
@@ -288,7 +288,7 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
     // there's nothing for the planner to do with them.
     let init_terms: BTreeSet<T> =
     seed.iter()
-        .copied()
+        .cloned()
         .filter(|t| terms_to_atoms.contains_key(t) || need.contains(t))
         .collect();
     // Body atoms whose terms are all already in `init_terms` should be present in stage 0.
@@ -315,7 +315,7 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
         // Pick the term incident on the most atoms (most-constrained-first).
         next_terms.sort_by_key(|t| terms_to_atoms[t].len());
         // Fallback: any groundable term, allowing cross joins with data-backed atoms.
-        let next_term = next_terms.last().copied().or_else(|| body.values()
+        let next_term = next_terms.last().cloned().or_else(|| body.values()
             .flat_map(|a| a.ground(&terms))
             .filter(|t| !terms.contains(t) && terms_to_atoms.contains_key(t))
             .next());
@@ -323,7 +323,7 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
         if let Some(next_term) = next_term {
             let mut next_atoms: BTreeSet<A> = terms_to_atoms[&next_term].iter()
                 .filter(|a| body[a].terms().contains(&next_term) && terms.iter().any(|t| body[a].terms().contains(t)))
-                .copied()
+                .cloned()
                 .collect();
             next_atoms.extend(body.iter()
                 .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term))
@@ -331,10 +331,10 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
             if next_atoms.is_empty() {
                 next_atoms = terms_to_atoms[&next_term].iter()
                     .filter(|a| body[a].terms().contains(&next_term))
-                    .copied()
+                    .cloned()
                     .collect();
             }
-            terms.insert(next_term);
+            terms.insert(next_term.clone());
             plan.push((next_atoms, [next_term].into_iter().collect(), Vec::new()));
         }
         else {
@@ -354,8 +354,8 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
     // Set each stage's projection target by demand from later stages plus `need`.
     for index in 1 .. plan.len() {
         let (this, rest) = plan.split_at_mut(index);
-        let present: Vec<T> = this.iter().flat_map(|(_, terms, _)| terms.iter()).copied().collect();
-        let demanded: Vec<T> = present.iter().copied().filter(|t| {
+        let present: Vec<T> = this.iter().flat_map(|(_, terms, _)| terms.iter()).cloned().collect();
+        let demanded: Vec<T> = present.iter().cloned().filter(|t| {
             rest.iter().any(|(atoms, _, _)| atoms.iter().any(|a| {
                 terms_to_atoms.get(t).map_or(false, |set| set.contains(a))
             })) || need.contains(t)
@@ -366,11 +366,11 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Copy+std::fmt::Debug>(
         for atom in rest[0].0.iter() {
             for term in demanded.iter() {
                 if terms_to_atoms.get(term).map_or(false, |set| set.contains(atom)) && !order.contains(term) {
-                    order.push(*term);
+                    order.push(term.clone());
                 }
             }
         }
-        for term in demanded.iter() { if !order.contains(term) { order.push(*term); } }
+        for term in demanded.iter() { if !order.contains(term) { order.push(term.clone()); } }
     }
     if let Some(last) = plan.last_mut() { last.2 = need.to_vec(); }
 

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -77,21 +77,7 @@ pub trait PlanAtom<T: Ord> {
 }
 
 use std::collections::{BTreeSet, BTreeMap};
-use crate::types::{Atom, Action, Term};
-
-/// Substitution map: body var name → its replacement under composition.
-///
-/// Each entry rewrites a body var to either another var (`Term::Var` — rename, often
-/// to a use-site var name to unify head and use-site spaces) or a literal
-/// (`Term::Lit` — constant pushdown, baked into atom load actions as `lit_filter`).
-/// Values are `Term` borrowed from the use-site atom; refs have `'a` lifetime so
-/// `PlanAtom` term sets and load actions can use the inner `String`/`Vec<u8>`
-/// directly without allocation.
-///
-/// Used by the view planner to fold use-site constraints into the body's atom views
-/// without allocating new `Atom` structs. `build_atoms_map` and `base_actions_for`
-/// consult this when computing per-atom term sets and load actions.
-pub type Subst = BTreeMap<String, Term>;
+use crate::types::{Atom, Action};
 
 /// A plan is a sequence of stages, each a tuple of (atoms, terms, output order).
 ///
@@ -119,16 +105,15 @@ pub type Loads<A, T> = BTreeMap<A, BTreeMap<A, Load<T>>>;
 /// term order targeting the terms of `head`.
 ///
 /// Seeds that cannot ground their own terms (e.g. logic atoms) are silently skipped.
-pub fn plan_rule<'a>(
-    head: &'a [Atom],
-    body: &'a [Atom],
+pub fn plan_rule(
+    head: &[Atom],
+    body: &[Atom],
     seed_atoms: &[usize],
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
 ) -> (Plans<usize, String>, Loads<usize, String>) {
 
-    let empty_subst: Subst = BTreeMap::new();
-    let head_terms = head_order(head, &empty_subst);
-    let base_actions = base_actions_for(body, &empty_subst);
+    let head_terms = head_order(head);
+    let base_actions = base_actions_for(body);
 
     let mut plans: Plans<usize, String> = BTreeMap::default();
     let mut loads: Loads<usize, String> = BTreeMap::default();
@@ -136,7 +121,7 @@ pub fn plan_rule<'a>(
     // One atoms map; each iteration takes a seed_idx out as the seed and puts it back
     // at the end. Same round-robin shape as semi-naive: the body's atoms are stable;
     // which one supplies the novelty rotates.
-    let mut atoms = build_atoms_map(body, &empty_subst, decls);
+    let mut atoms = build_atoms_map(body, decls);
     for &seed_idx in seed_atoms {
         if let Some(seed_atom) = atoms.remove(&seed_idx) {
             if seed_atom.terms() == seed_atom.ground(&Default::default()) {
@@ -163,9 +148,9 @@ pub fn plan_rule<'a>(
 /// This is informed by `plan`, which reveals atoms in the first stages that we
 /// may try to align the terms of `seed` to match.
 /// It is unclear if this is worth the cost of a new form for the seed.
-fn seed_load<'a>(
+fn seed_load(
     plan: &Plan<usize, String>,
-    body: &BTreeMap<usize, Box<dyn PlanAtom<String> + 'a>>,
+    body: &BTreeMap<usize, Box<dyn PlanAtom<String>>>,
     seed_terms: &BTreeSet<String>,
     base_action: &Action<Vec<u8>>,
 ) -> Load<String> {
@@ -220,21 +205,12 @@ fn body_load<'a, A: Ord + Copy, T: Ord + Clone>(
 
 /// Produces a term order for head atoms.
 ///
-/// The order is of distinct terms in order of presentation, with `subst` applied
-/// (Var→Var renames are reflected; Var→Lit substitutions drop out, as do raw lits).
-/// Pass empty `Subst` for the non-view path.
-fn head_order<'a>(head: &'a [Atom], subst: &Subst) -> Vec<String> {
+/// The order is of distinct terms in order of presentation. Literals are dropped.
+fn head_order(head: &[Atom]) -> Vec<String> {
     let mut seen: BTreeSet<String> = BTreeSet::default();
     head.iter()
         .flat_map(|a| a.terms.iter())
-        .filter_map(|t| match t {
-            Term::Var(name) => match subst.get(name) {
-                Some(Term::Var(new_name)) => Some(new_name.clone()),
-                Some(Term::Lit(_)) => None,
-                None => Some(name.clone()),
-            },
-            Term::Lit(_) => None,
-        })
+        .filter_map(|t| t.as_var().cloned())
         .filter(|t| seen.insert(t.clone()))
         .collect()
 }
@@ -245,15 +221,14 @@ fn head_order<'a>(head: &'a [Atom], subst: &Subst) -> Vec<String> {
 /// caller (e.g. a sum atom disjunct) already holds the seed bindings in an input
 /// salad and wants stages that introduce the rest of the body's variables. The single
 /// head atom matches the disjunct shape — multi-head rules don't arise on this path.
-pub fn plan_rule_seeded<'a>(
-    body: &'a [Atom],
+pub fn plan_rule_seeded(
+    body: &[Atom],
     seed: &[String],
     need: &[String],
-    subst: &Subst,
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
+    decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
 ) -> (Plan<usize, String>, BTreeMap<usize, Load<String>>) {
-    let atoms = build_atoms_map(body, subst, decls);
-    let base_actions = base_actions_for(body, subst);
+    let atoms = build_atoms_map(body, decls);
+    let base_actions = base_actions_for(body);
     let plan = plan_body(seed, &atoms, need);
     let loads = body_load(&plan, &atoms, &base_actions);
     (plan, loads)
@@ -386,30 +361,14 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
 /// Dispatches on atom kind: logic atoms (`logic::resolve`), views
 /// (`view::ViewPlan`), antijoins (`anti::Anti`), or plain data relations (a bare
 /// `BTreeSet` of variable terms).
-///
-/// `subst` lets the caller fold composition-derived constraints into the per-atom view
-/// without rewriting the atom: a body var mapped to `Term::Var(new_name)` is
-/// renamed; a body var mapped to `Term::Lit(_)` drops out of the var set (it's
-/// a known constant — the lit_filter is added by `base_actions_for`). Pass an empty
-/// `Subst` for the non-view planning path. Logic atoms participate in subst via
-/// `logic::resolve_with_subst`, so renamed/pushed vars also flow into their `bound`
-/// and `terms`.
-fn build_atoms_map<'a>(
-    body: &'a [Atom],
-    subst: &Subst,
-    decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-) -> BTreeMap<usize, Box<dyn PlanAtom<String> + 'a>> {
+fn build_atoms_map(
+    body: &[Atom],
+    decls: &std::collections::BTreeMap<String, crate::types::RelationDecl>,
+) -> BTreeMap<usize, Box<dyn PlanAtom<String>>> {
     body.iter().enumerate().map(|(index, atom)| {
-        let terms: BTreeSet<String> = atom.terms.iter().filter_map(|t| match t {
-            Term::Var(name) => match subst.get(name) {
-                Some(Term::Var(new_name)) => Some(new_name.clone()),
-                Some(Term::Lit(_)) => None,
-                None => Some(name.clone()),
-            },
-            Term::Lit(_) => None,
-        }).collect();
-        let boxed_atom: Box<dyn PlanAtom<String>+'a> =
-        if let Some(logic) = crate::rules::atoms::logic::resolve_with_subst(atom, subst) { Box::new(logic) }
+        let terms: BTreeSet<String> = atom.terms.iter().filter_map(|t| t.as_var().cloned()).collect();
+        let boxed_atom: Box<dyn PlanAtom<String>> =
+        if let Some(logic) = crate::rules::atoms::logic::resolve(atom) { Box::new(logic) }
         else if decls.get(atom.name.as_str()).map_or(false, |d| d.view) {
             Box::new(crate::rules::atoms::view::ViewPlan { head_terms: terms })
         }
@@ -421,63 +380,10 @@ fn build_atoms_map<'a>(
 
 /// Per-atom action that materializes facts in the atom's variable-name-sorted order.
 /// Reference point for deriving plan-specific load actions.
-///
-/// `subst` is applied while building each atom's action: a body var mapped to
-/// `Term::Lit(value)` becomes a positional literal (lit_filter); a body var
-/// mapped to `Term::Var(new_name)` is renamed (affecting var_filter detection
-/// for repeats and the projection's sort order). Pass empty `Subst` for the
-/// non-view path.
-fn base_actions_for<'a>(body: &[Atom], subst: &Subst) -> BTreeMap<usize, Action<Vec<u8>>> {
+fn base_actions_for(body: &[Atom]) -> BTreeMap<usize, Action<Vec<u8>>> {
     body.iter().enumerate().map(|(index, atom)| {
-        let mut action = action_from_body_with_subst(atom, subst);
-        // Sort projection by the substituted var name (the var name as the planner sees it).
-        action.projection.sort_by_key(|p| {
-            let pos = *p.as_ref().unwrap();
-            // After substitution, projection only references positions whose effective term is a Var.
-            match &atom.terms[pos] {
-                Term::Var(name) => match subst.get(name) {
-                    Some(Term::Var(new_name)) => new_name,
-                    Some(Term::Lit(_)) => unreachable!("Lit positions don't appear in projection"),
-                    None => name,
-                },
-                Term::Lit(_) => unreachable!("Lit positions don't appear in projection"),
-            }
-        });
+        let mut action = Action::from_body(atom);
+        action.projection.sort_by_key(|p| atom.terms[*p.as_ref().unwrap()].as_var().unwrap().clone());
         (index, action)
     }).collect()
-}
-
-/// Builds an `Action` from an atom, applying `subst` as it walks each term.
-///
-/// Mirrors `Action::from_body` but routes each var through `subst`: a Var → Lit
-/// substitution becomes a positional `lit_filter`; a Var → Var substitution renames
-/// (so repeats with the renamed name produce `var_filter` entries).
-fn action_from_body_with_subst<'a>(atom: &Atom, subst: &Subst) -> Action<Vec<u8>> {
-    let mut output = Action::default();
-    let mut terms_seen: BTreeMap<&str, usize> = BTreeMap::default();
-    for (index, term) in atom.terms.iter().enumerate() {
-        // Resolve to the effective post-substitution view: either a var name or lit bytes.
-        let (eff_var, eff_lit): (Option<&str>, Option<&[u8]>) = match term {
-            Term::Var(name) => match subst.get(name) {
-                Some(Term::Var(new_name)) => (Some(new_name.as_str()), None),
-                Some(Term::Lit(value)) => (None, Some(value.as_slice())),
-                None => (Some(name.as_str()), None),
-            },
-            Term::Lit(value) => (None, Some(value.as_slice())),
-        };
-        if let Some(var_name) = eff_var {
-            if !terms_seen.contains_key(var_name) {
-                let new_idx = terms_seen.len();
-                terms_seen.insert(var_name, new_idx);
-                output.var_filter.push(Vec::default());
-                output.projection.push(Ok(index));
-            }
-            output.var_filter[terms_seen[var_name]].push(index);
-        } else if let Some(value) = eff_lit {
-            output.lit_filter.push((index, value.to_vec()));
-        }
-    }
-    output.var_filter.retain(|list| list.len() > 1);
-    output.input_arity = atom.terms.len();
-    output
 }

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -84,14 +84,14 @@ use crate::types::{Atom, Action, Term};
 /// Each entry rewrites a body var to either another var (`Term::Var` — rename, often
 /// to a use-site var name to unify head and use-site spaces) or a literal
 /// (`Term::Lit` — constant pushdown, baked into atom load actions as `lit_filter`).
-/// Values are `&'a Term` borrowed from the use-site atom; refs have `'a` lifetime so
-/// `PlanAtom` term sets and load actions can use the inner `&'a String`/`&'a Vec<u8>`
+/// Values are `Term` borrowed from the use-site atom; refs have `'a` lifetime so
+/// `PlanAtom` term sets and load actions can use the inner `String`/`Vec<u8>`
 /// directly without allocation.
 ///
 /// Used by the view planner to fold use-site constraints into the body's atom views
 /// without allocating new `Atom` structs. `build_atoms_map` and `base_actions_for`
 /// consult this when computing per-atom term sets and load actions.
-pub type Subst<'a> = BTreeMap<&'a String, &'a Term>;
+pub type Subst = BTreeMap<String, Term>;
 
 /// A plan is a sequence of stages, each a tuple of (atoms, terms, output order).
 ///
@@ -124,14 +124,14 @@ pub fn plan_rule<'a>(
     body: &'a [Atom],
     seed_atoms: &[usize],
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-) -> (Plans<usize, &'a String>, Loads<usize, &'a String>) {
+) -> (Plans<usize, String>, Loads<usize, String>) {
 
-    let empty_subst: Subst<'a> = BTreeMap::new();
+    let empty_subst: Subst = BTreeMap::new();
     let head_terms = head_order(head, &empty_subst);
     let base_actions = base_actions_for(body, &empty_subst);
 
-    let mut plans: Plans<usize, &'a String> = BTreeMap::default();
-    let mut loads: Loads<usize, &'a String> = BTreeMap::default();
+    let mut plans: Plans<usize, String> = BTreeMap::default();
+    let mut loads: Loads<usize, String> = BTreeMap::default();
 
     // One atoms map; each iteration takes a seed_idx out as the seed and puts it back
     // at the end. Same round-robin shape as semi-naive: the body's atoms are stable;
@@ -144,7 +144,7 @@ pub fn plan_rule<'a>(
                 // Body-positional, possibly with repeats — preserves the user-written
                 // column order so the planner can prefer stage-0 atoms that align with
                 // the seed's column prefix (avoiding a re-permute on first semijoin).
-                let seed: Vec<&'a String> = body[seed_idx].terms.iter().filter_map(|t| t.as_var()).collect();
+                let seed: Vec<String> = body[seed_idx].terms.iter().filter_map(|t| t.as_var().cloned()).collect();
                 let plan = plan_body(&seed, &atoms, &head_terms);
                 let mut load = body_load(&plan, &atoms, &base_actions);
                 load.insert(seed_idx, seed_load(&plan, &atoms, &seed_terms, &base_actions[&seed_idx]));
@@ -164,20 +164,21 @@ pub fn plan_rule<'a>(
 /// may try to align the terms of `seed` to match.
 /// It is unclear if this is worth the cost of a new form for the seed.
 fn seed_load<'a>(
-    plan: &Plan<usize, &'a String>,
-    body: &BTreeMap<usize, Box<dyn PlanAtom<&'a String> + 'a>>,
-    seed_terms: &BTreeSet<&'a String>,
+    plan: &Plan<usize, String>,
+    body: &BTreeMap<usize, Box<dyn PlanAtom<String> + 'a>>,
+    seed_terms: &BTreeSet<String>,
     base_action: &Action<Vec<u8>>,
-) -> Load<&'a String> {
+) -> Load<String> {
     let mut order = Vec::new();
     if let Some((stage_atoms, _, _)) = plan.iter().find(|(a, _, _)| !a.is_empty()) {
         for atom in stage_atoms.iter() {
-            for term in body[atom].terms().intersection(seed_terms) {
-                if !order.contains(term) { order.push(*term); }
+            let atom_terms = body[atom].terms();
+            for term in atom_terms.intersection(seed_terms) {
+                if !order.contains(term) { order.push(term.clone()); }
             }
         }
     }
-    for term in seed_terms.iter() { if !order.contains(term) { order.push(*term); } }
+    for term in seed_terms.iter() { if !order.contains(term) { order.push(term.clone()); } }
 
     let mut action = base_action.clone();
     action.projection = order.iter()
@@ -222,19 +223,19 @@ fn body_load<'a, A: Ord + Copy, T: Ord + Clone>(
 /// The order is of distinct terms in order of presentation, with `subst` applied
 /// (Var→Var renames are reflected; Var→Lit substitutions drop out, as do raw lits).
 /// Pass empty `Subst` for the non-view path.
-fn head_order<'a>(head: &'a [Atom], subst: &Subst<'a>) -> Vec<&'a String> {
-    let mut seen: BTreeSet<&'a String> = BTreeSet::default();
+fn head_order<'a>(head: &'a [Atom], subst: &Subst) -> Vec<String> {
+    let mut seen: BTreeSet<String> = BTreeSet::default();
     head.iter()
         .flat_map(|a| a.terms.iter())
         .filter_map(|t| match t {
             Term::Var(name) => match subst.get(name) {
-                Some(Term::Var(new_name)) => Some(new_name),
+                Some(Term::Var(new_name)) => Some(new_name.clone()),
                 Some(Term::Lit(_)) => None,
-                None => Some(name),
+                None => Some(name.clone()),
             },
             Term::Lit(_) => None,
         })
-        .filter(|t| seen.insert(t))
+        .filter(|t| seen.insert(t.clone()))
         .collect()
 }
 
@@ -246,11 +247,11 @@ fn head_order<'a>(head: &'a [Atom], subst: &Subst<'a>) -> Vec<&'a String> {
 /// head atom matches the disjunct shape — multi-head rules don't arise on this path.
 pub fn plan_rule_seeded<'a>(
     body: &'a [Atom],
-    seed: &[&'a String],
-    need: &[&'a String],
-    subst: &Subst<'a>,
+    seed: &[String],
+    need: &[String],
+    subst: &Subst,
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-) -> (Plan<usize, &'a String>, BTreeMap<usize, Load<&'a String>>) {
+) -> (Plan<usize, String>, BTreeMap<usize, Load<String>>) {
     let atoms = build_atoms_map(body, subst, decls);
     let base_actions = base_actions_for(body, subst);
     let plan = plan_body(seed, &atoms, need);
@@ -395,19 +396,19 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
 /// and `terms`.
 fn build_atoms_map<'a>(
     body: &'a [Atom],
-    subst: &Subst<'a>,
+    subst: &Subst,
     decls: &'a std::collections::BTreeMap<String, crate::types::RelationDecl>,
-) -> BTreeMap<usize, Box<dyn PlanAtom<&'a String> + 'a>> {
+) -> BTreeMap<usize, Box<dyn PlanAtom<String> + 'a>> {
     body.iter().enumerate().map(|(index, atom)| {
-        let terms: BTreeSet<&'a String> = atom.terms.iter().filter_map(|t| match t {
+        let terms: BTreeSet<String> = atom.terms.iter().filter_map(|t| match t {
             Term::Var(name) => match subst.get(name) {
-                Some(Term::Var(new_name)) => Some(new_name),
+                Some(Term::Var(new_name)) => Some(new_name.clone()),
                 Some(Term::Lit(_)) => None,
-                None => Some(name),
+                None => Some(name.clone()),
             },
             Term::Lit(_) => None,
         }).collect();
-        let boxed_atom: Box<dyn PlanAtom<&'a String>+'a> =
+        let boxed_atom: Box<dyn PlanAtom<String>+'a> =
         if let Some(logic) = crate::rules::atoms::logic::resolve_with_subst(atom, subst) { Box::new(logic) }
         else if decls.get(atom.name.as_str()).map_or(false, |d| d.view) {
             Box::new(crate::rules::atoms::view::ViewPlan { head_terms: terms })
@@ -426,7 +427,7 @@ fn build_atoms_map<'a>(
 /// mapped to `Term::Var(new_name)` is renamed (affecting var_filter detection
 /// for repeats and the projection's sort order). Pass empty `Subst` for the
 /// non-view path.
-fn base_actions_for<'a>(body: &[Atom], subst: &Subst<'a>) -> BTreeMap<usize, Action<Vec<u8>>> {
+fn base_actions_for<'a>(body: &[Atom], subst: &Subst) -> BTreeMap<usize, Action<Vec<u8>>> {
     body.iter().enumerate().map(|(index, atom)| {
         let mut action = action_from_body_with_subst(atom, subst);
         // Sort projection by the substituted var name (the var name as the planner sees it).
@@ -451,7 +452,7 @@ fn base_actions_for<'a>(body: &[Atom], subst: &Subst<'a>) -> BTreeMap<usize, Act
 /// Mirrors `Action::from_body` but routes each var through `subst`: a Var → Lit
 /// substitution becomes a positional `lit_filter`; a Var → Var substitution renames
 /// (so repeats with the renamed name produce `var_filter` entries).
-fn action_from_body_with_subst<'a>(atom: &Atom, subst: &Subst<'a>) -> Action<Vec<u8>> {
+fn action_from_body_with_subst<'a>(atom: &Atom, subst: &Subst) -> Action<Vec<u8>> {
     let mut output = Action::default();
     let mut terms_seen: BTreeMap<&str, usize> = BTreeMap::default();
     for (index, term) in atom.terms.iter().enumerate() {


### PR DESCRIPTION
Changes that spill out from using `String` to reference terms, rather than `&String`. There is more ownership, but a lot less lifetime pfaffery which also removes some chaos around live-substituting terms as we work through them (due to needing lifetimes vs owned things). Anyhow, meant to tidy up a fair bit, at the cost of some string cloning at plan time. If it ends up badly, we can use `Rc<String>` instead.