### PR TITLE
Correct some zero-arity asserts

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -98,6 +98,28 @@ impl Comms {
         }
     }
 
+    /// All-reduce sum across peers. Returns the same value on every peer.
+    pub fn all_reduce_sum(&mut self, value: u64) -> u64 {
+        if self.peers() == 1 { return value; }
+        use columnar::Push;
+        let mut facts = FactLSM::default();
+        let mut column = Terms::default();
+        column.push(&value.to_be_bytes().to_vec());
+        if let Some(forest) = Forest::from_columns(vec![column]) { facts.extend([forest]); }
+        self.broadcast(&mut facts);
+        let mut total: u64 = 0;
+        if let Some(flat) = facts.flatten() {
+            use columnar::Borrow;
+            for i in 0 .. flat.layer(0).list.values.len() {
+                let bytes = flat.layer(0).list.values.borrow().get(i).as_slice();
+                if bytes.len() == 8 {
+                    total += u64::from_be_bytes(bytes.try_into().unwrap());
+                }
+            }
+        }
+        total
+    }
+
     /// Exchanges facts among all workers.
     pub fn exchange(&mut self, facts: &mut FactLSM<Forest<Terms>>) {
         let mut conduit = self.conduit();

--- a/src/rules/atoms/anti.rs
+++ b/src/rules/atoms/anti.rs
@@ -27,8 +27,13 @@ impl<T: Ord + Clone+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<Forest<Terms>>, V
         let (my_facts, my_terms) = &self.0;
         let prefix = my_terms.iter().take_while(|t| salad.terms.contains(t)).count();
         salad.align_to(comms, my_terms[..prefix].iter().cloned());
-        // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
-        assert!(prefix > 0 || comms.peers() == 1);
+        if prefix == 0 && comms.peers() > 1 {
+            // Zero-prefix antijoin: drop salad iff atom is globally non-empty.
+            assert!(terms.is_empty());
+            let any_local: u64 = (!my_facts.is_empty()) as u64;
+            if comms.all_reduce_sum(any_local) > 0 { salad.facts = Default::default(); }
+            return;
+        }
         if let Some(delta) = salad.facts.flatten() {
             assert!(terms.is_empty());
             let others = my_facts.iter().map(|o| o.borrow()).collect::<Vec<_>>();

--- a/src/rules/atoms/data.rs
+++ b/src/rules/atoms/data.rs
@@ -35,8 +35,6 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
 
         let prefix = other_terms.iter().take_while(|t| salad.terms.contains(t)).count();
         salad.align_to(comms, other_terms[..prefix].iter().cloned());
-        // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
-        assert!(prefix > 0 || comms.peers() == 1);
         if let Some(mut delta) = salad.facts.flatten() {
             let length = if prefix > 0 { delta.layer(prefix-1).list.values.len() } else { 1 };
             let mut counts = vec![0; length];
@@ -48,6 +46,9 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
                 let mut ranges = other_idxs.iter().map(|i| (*i,*i+1)).collect::<Vec<_>>();
                 for layer in prefix .. (prefix + terms.len()) { advance_bounds::<Terms>(other_part.layer(layer).borrow(), &mut ranges); }
                 for (delta_idx, range) in delta_idxs.iter().zip(ranges.iter()) { counts[*delta_idx] += range.1-range.0; }
+            }
+            if prefix == 0 && comms.peers() > 1 {
+                counts[0] = comms.all_reduce_sum(counts[0] as u64) as usize;
             }
 
             // We now project `counts` forward through `delta` to the `potato` column.
@@ -106,7 +107,15 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
         let (my_facts, my_terms, _) = self;
         let prefix = my_terms.iter().take_while(|t| salad.terms.contains(t)).count();
         salad.align_to(comms, my_terms[..prefix].iter().cloned());
-        // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
+        if prefix == 0 && comms.peers() > 1 && terms.is_empty() {
+            // Zero-prefix semijoin: retain salad iff atom is globally non-empty.
+            let any_local: u64 = (!my_facts.is_empty()) as u64;
+            if comms.all_reduce_sum(any_local) == 0 { salad.facts = Default::default(); }
+            return;
+        }
+        // Remaining zero-prefix multi-worker case is the cross-product join
+        // (`!terms.is_empty()`), which would need a broadcast or gather to be
+        // correct. Currently unreachable from the planner.
         assert!(prefix > 0 || comms.peers() == 1);
         if !terms.is_empty() {
             // join with atom: permute `salad.terms` into the right order, join adding the new column, permute into target order (`delta_terms_new`).

--- a/src/rules/exec.rs
+++ b/src/rules/exec.rs
@@ -159,7 +159,9 @@ pub fn wco_join<T: Ord + Clone + std::fmt::Debug>(
             wco_join_inner(comms, &mut prefix, terms, atoms, potato, &shared_target);
             prefix.align_to(comms, salad.terms[..shared.len()].iter().cloned());
 
-            // FIXME: the shuffling above is insufficient if the arity is zero and there are multiple workers.
+            // Zero shared columns multi-worker would be a cross-product; needs
+            // broadcast/gather of `prefix` (or `salad`) to be correct.
+            // Currently unreachable from the planner.
             assert!(shared.len() > 0 || comms.peers() == 1);
 
             // Re-install sequestered terms.

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -297,13 +297,21 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
             .next());
 
         if let Some(next_term) = next_term {
-            let mut next_atoms: BTreeSet<A> = terms_to_atoms[&next_term].iter()
-                .filter(|a| body[a].terms().contains(&next_term) && terms.iter().any(|t| body[a].terms().contains(t)))
-                .cloned()
+            // Atoms that ground `next_term` AND share at least one already-bound term:
+            // these are real (non-cross-product) participants.
+            let constrained: BTreeSet<A> = body.iter()
+                .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term)
+                    && terms.iter().any(|t| boxed.terms().contains(t)))
+                .map(|(a, _)| *a)
                 .collect();
-            next_atoms.extend(body.iter()
-                .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term))
-                .map(|(a, _)| *a));
+            // Fall back to any atom grounding `next_term` (including cross-product
+            // candidates) only when no constrained atoms exist for this term.
+            let mut next_atoms = constrained;
+            if next_atoms.is_empty() {
+                next_atoms.extend(body.iter()
+                    .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term))
+                    .map(|(a, _)| *a));
+            }
             if next_atoms.is_empty() {
                 next_atoms = terms_to_atoms[&next_term].iter()
                     .filter(|a| body[a].terms().contains(&next_term))


### PR DESCRIPTION
Several moments where we exchange with no arity in common, we assert if we have more than one worker. Some of these cases are easy to correct, with an all-reduce. Others like cross joins are not fixed here. This unlocks most of the FlowLog benchmarks with multiple workers.