### PR TITLE
Broadcast cross join

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -98,6 +98,18 @@ impl Comms {
         }
     }
 
+    /// Logical-OR across peers: `true` if any worker passes `true`.
+    pub fn any(&mut self, local: bool) -> bool {
+        if self.peers() == 1 { return local; }
+        self.all_reduce_sum(local as u64) > 0
+    }
+
+    /// Logical-AND across peers: `true` only if every worker passes `true`.
+    pub fn all(&mut self, local: bool) -> bool {
+        if self.peers() == 1 { return local; }
+        self.all_reduce_sum((!local) as u64) == 0
+    }
+
     /// All-reduce sum across peers. Returns the same value on every peer.
     pub fn all_reduce_sum(&mut self, value: u64) -> u64 {
         if self.peers() == 1 { return value; }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -111,12 +111,20 @@ impl Comms {
     }
 
     /// All-reduce sum across peers. Returns the same value on every peer.
+    ///
+    /// Each contribution is tagged with the sender's index so that workers
+    /// reporting the same `value` produce distinct rows after broadcast.
+    /// Without the tag, `flatten()` (which unions / deduplicates) would
+    /// collapse equal contributions and silently undercount the sum.
     pub fn all_reduce_sum(&mut self, value: u64) -> u64 {
         if self.peers() == 1 { return value; }
         use columnar::Push;
         let mut facts = FactLSM::default();
         let mut column = Terms::default();
-        column.push(&value.to_be_bytes().to_vec());
+        let mut buf = [0u8; 16];
+        buf[..8].copy_from_slice(&(self.index() as u64).to_be_bytes());
+        buf[8..].copy_from_slice(&value.to_be_bytes());
+        column.push(&buf.to_vec());
         if let Some(forest) = Forest::from_columns(vec![column]) { facts.extend([forest]); }
         self.broadcast(&mut facts);
         let mut total: u64 = 0;
@@ -124,8 +132,8 @@ impl Comms {
             use columnar::Borrow;
             for i in 0 .. flat.layer(0).list.values.len() {
                 let bytes = flat.layer(0).list.values.borrow().get(i).as_slice();
-                if bytes.len() == 8 {
-                    total += u64::from_be_bytes(bytes.try_into().unwrap());
+                if bytes.len() == 16 {
+                    total += u64::from_be_bytes(bytes[8..].try_into().unwrap());
                 }
             }
         }

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -99,12 +99,24 @@ impl Relations {
             for layer in base.stable.contents() {
                 fact_set.stable.extend(layer.act_on(action, thresh));
             }
-            comms.exchange(&mut fact_set.stable);
+            // 0-arity results (proj: []) have no partition key — they are
+            // presence/absence markers that must be replicated, not sharded.
+            // Static dispatch by the action's output arity keeps the choice
+            // identical across workers (no per-worker state inspection).
+            if action.projection.is_empty() {
+                comms.broadcast(&mut fact_set.stable);
+            } else {
+                comms.exchange(&mut fact_set.stable);
+            }
             // Flattening deduplicates, which may be necessary as `action` may introduce collisions
             // across LSM layers.
             if let Some(stable) = fact_set.stable.flatten() { fact_set.stable.push(stable); }
             let mut acted_on = if let Some(recent) = base.recent.as_ref() { recent.act_on(action, thresh) } else { FactLSM::default() };
-            comms.exchange(&mut acted_on);
+            if action.projection.is_empty() {
+                comms.broadcast(&mut acted_on);
+            } else {
+                comms.exchange(&mut acted_on);
+            }
             if let Some(recent) = acted_on.flatten() {
                 fact_set.recent = recent.antijoin(fact_set.stable.contents()).flatten();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,13 @@ pub mod types {
         }
 
         pub fn extend_facts(&mut self, atom: &Atom, mut facts: crate::facts::FactLSM<crate::facts::Forest<crate::facts::Terms>>) {
-            self.comms.exchange(&mut facts);
+            // 0-arity heads are presence markers, not sharded relations:
+            // replicate via broadcast rather than partition-by-column-0.
+            if atom.terms.is_empty() {
+                self.comms.broadcast(&mut facts);
+            } else {
+                self.comms.exchange(&mut facts);
+            }
             // Always materialize the relation entry — see extend_facts_with_fields
             // in src/rules/mod.rs for the rationale.
             let entry = self.facts.entry(&atom);

--- a/src/rules/atoms/anti.rs
+++ b/src/rules/atoms/anti.rs
@@ -30,8 +30,7 @@ impl<T: Ord + Clone+std::fmt::Debug> ExecAtom<T> for Anti<(Vec<Forest<Terms>>, V
         if prefix == 0 && comms.peers() > 1 {
             // Zero-prefix antijoin: drop salad iff atom is globally non-empty.
             assert!(terms.is_empty());
-            let any_local: u64 = (!my_facts.is_empty()) as u64;
-            if comms.all_reduce_sum(any_local) > 0 { salad.facts = Default::default(); }
+            if comms.any(!my_facts.is_empty()) { salad.facts = Default::default(); }
             return;
         }
         if let Some(delta) = salad.facts.flatten() {

--- a/src/rules/atoms/data.rs
+++ b/src/rules/atoms/data.rs
@@ -126,16 +126,41 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
             // Zero-prefix semijoin: retain salad iff atom is globally non-empty.
             // `retain_inner` with empty prefix slices underflows (`other_arity - 1`
             // when `other_arity == 0`), so we must short-circuit even in
-            // single-worker runs. Multi-worker case uses an all-reduce.
-            let any_local: u64 = (!my_facts.is_empty()) as u64;
-            let any_global = if comms.peers() > 1 { comms.all_reduce_sum(any_local) } else { any_local };
-            if any_global == 0 { salad.facts = Default::default(); }
+            // single-worker runs.
+            if !comms.any(!my_facts.is_empty()) { salad.facts = Default::default(); }
             return;
         }
-        // Remaining zero-prefix multi-worker case is the cross-product join
-        // (`!terms.is_empty()`), which would need a broadcast or gather to be
-        // correct. Currently unreachable from the planner.
-        assert!(prefix > 0 || comms.peers() == 1);
+        if prefix == 0 && comms.peers() > 1 {
+            // Zero-prefix multi-worker cross-product. Broadcast the salad so
+            // every worker holds the full union, then locally cross-join with
+            // this worker's atom shard. The output's column 0 is from the atom
+            // side, preserving the "column 0 is the partition key" invariant
+            // without any further coordination. Single-worker prefix-0 falls
+            // through to `join_many` below, which handles the local Cartesian.
+            use columnar::{Borrow, Container, Len};
+            use crate::facts::trie::Layer;
+            comms.broadcast(&mut salad.facts);
+            if let Some(salad_full) = salad.facts.flatten() {
+                for atom_part in my_facts.iter() {
+                    let n = atom_part.len();
+                    if n == 0 { continue; }
+                    let mut layers: Vec<Rc<Layer<Terms>>> = (0..atom_part.arity()).map(|i| atom_part.layer(i).clone()).collect();
+                    for j in 0..salad_full.arity() {
+                        let sj = salad_full.layer(j);
+                        let mut list = sj.list.clone();
+                        for _ in 1..n {
+                            list.extend_from_self(sj.list.borrow(), 0..sj.list.len());
+                        }
+                        layers.push(Rc::new(Layer { list }));
+                    }
+                    salad.facts.extend([layers.try_into().expect("non-empty by construction")]);
+                }
+            }
+            let prior_terms = std::mem::take(&mut salad.terms);
+            salad.terms = my_terms.iter().chain(prior_terms.iter()).cloned().collect();
+            salad.align_to(comms, after.iter().cloned());
+            return;
+        }
         if !terms.is_empty() {
             // join with atom: permute `salad.terms` into the right order, join adding the new column, permute into target order (`delta_terms_new`).
             let conduit = comms.conduit();

--- a/src/rules/exec.rs
+++ b/src/rules/exec.rs
@@ -159,25 +159,55 @@ pub fn wco_join<T: Ord + Clone + std::fmt::Debug>(
             wco_join_inner(comms, &mut prefix, terms, atoms, potato, &shared_target);
             prefix.align_to(comms, salad.terms[..shared.len()].iter().cloned());
 
-            // Zero shared columns multi-worker would be a cross-product; needs
-            // broadcast/gather of `prefix` (or `salad`) to be correct.
-            // Currently unreachable from the planner.
-            assert!(shared.len() > 0 || comms.peers() == 1);
-
-            // Re-install sequestered terms.
-            let conduit = comms.conduit();
-            if let Some(facts) = salad.facts.flatten() {
-                let mut crossed_terms = salad.terms.clone();
-                crossed_terms.extend(salad.terms[..shared.len()].iter().cloned());
-                crossed_terms.extend(terms.iter().cloned());
-                let projection = target.iter().map(|t| crossed_terms.iter().position(|t2| t == t2).unwrap()).collect::<Vec<_>>();
-                salad.facts = facts.join_many(prefix.facts.contents(), shared.len(), &projection[..], conduit);
+            if shared.len() == 0 && comms.peers() > 1 {
+                // Wrapper-level zero-shared cross-product. Symmetric with the
+                // prefix-0 case in `data.rs::join`: broadcast `salad` (the
+                // sequestered original) so every worker holds the full union,
+                // then locally cross-join with `prefix` (the WCO inner output).
+                // Column 0 of the result is from `prefix` (a new term),
+                // preserving the "column 0 is the partition key" invariant —
+                // each worker only has its shard of `prefix`, so the local
+                // contribution to the global Cartesian is exactly the slice
+                // whose key falls on this worker.
+                use columnar::{Borrow, Container, Len};
+                use crate::facts::trie::Layer;
+                comms.broadcast(&mut salad.facts);
+                let mut out = FactLSM::default();
+                if let Some(salad_full) = salad.facts.flatten() {
+                    for prefix_part in prefix.facts.contents() {
+                        let n = prefix_part.len();
+                        if n == 0 { continue; }
+                        let mut layers: Vec<Rc<Layer<Terms>>> = (0..prefix_part.arity()).map(|i| prefix_part.layer(i).clone()).collect();
+                        for j in 0..salad_full.arity() {
+                            let sj = salad_full.layer(j);
+                            let mut list = sj.list.clone();
+                            for _ in 1..n {
+                                list.extend_from_self(sj.list.borrow(), 0..sj.list.len());
+                            }
+                            layers.push(Rc::new(Layer { list }));
+                        }
+                        out.extend([layers.try_into().expect("non-empty by construction")]);
+                    }
+                }
+                salad.facts = out;
+                salad.terms = prefix.terms.iter().chain(salad.terms.iter()).cloned().collect();
+                salad.align_to(comms, target.iter().cloned());
+            } else {
+                // Re-install sequestered terms.
+                let conduit = comms.conduit();
+                if let Some(facts) = salad.facts.flatten() {
+                    let mut crossed_terms = salad.terms.clone();
+                    crossed_terms.extend(salad.terms[..shared.len()].iter().cloned());
+                    crossed_terms.extend(terms.iter().cloned());
+                    let projection = target.iter().map(|t| crossed_terms.iter().position(|t2| t == t2).unwrap()).collect::<Vec<_>>();
+                    salad.facts = facts.join_many(prefix.facts.contents(), shared.len(), &projection[..], conduit);
+                }
+                else {
+                    salad.facts = conduit.finish();
+                }
+                salad.terms.clear();
+                salad.terms.extend_from_slice(target);
             }
-            else {
-                salad.facts = conduit.finish();
-            }
-            salad.terms.clear();
-            salad.terms.extend_from_slice(target);
         }
         else { wco_join_inner(comms, salad, terms, atoms, potato, target) }
     }

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -284,7 +284,13 @@ pub fn extend_facts_with_fields(
     atom: &Atom,
     mut data: crate::facts::FactLSM<Forest<Terms>>,
 ) {
-    comms.exchange(&mut data);
+    // 0-arity heads are presence markers, not sharded relations:
+    // replicate via broadcast rather than partition-by-column-0.
+    if atom.terms.is_empty() {
+        comms.broadcast(&mut data);
+    } else {
+        comms.exchange(&mut data);
+    }
     // Always materialize the relation entry, even when this worker's shard is
     // empty. Otherwise the BTreeMap key set diverges across workers and the
     // index-based `active` set (via `active_indices`) means different relations


### PR DESCRIPTION
This PR fixes the remaining instances of cross joins failing in distributed execution.

Cross joins have historically failed because the implementation idiom is to exchange by leading column, and then perform worker-local operation on partitioned data. Without a leading column, all data should be shuffled to one location, but .. we don't want to do that. Several "easier" fixes have already landed, to moments where the state is bounded (e.g. count across all workers, or boolean tests). These remaining two moments involve a cross join between `salad` and some `atom`.

1. The first fix is for an actual cross join: we have to join, and there are no terms in common. The strategy is to broadcast `salad`, and append it to the already partitioned facts of `atom`. This results in correctly partitioned data (`atom` is assumed to be distributed by its first column), and does no more work than we produce in output (`|salad| x |atom|`).
2. The second fix is for the column sequestration as we enter a join phase. Columns uninvolved in a join are held back, and only the columns that overlapped with joined atoms are retained. Once the join completes, the sequestered columns are reintroduced, using a join on the retained columns. If these are empty, we have a cross join in the style of just above. The same remedy is used.

We also found and fixed a bug where `all_reduce_sum` was deduplicating summands, and needed to have its data prefixed by a worker id to avoid this behavior.