### PR TITLE
Memory improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ columnar = "0.12"
 getopts = { version = "0.2.24" }
 regex = "1.11.1"
 mimalloc = { version = "0.1.48", features = ["v3"] }
+libmimalloc-sys = { version = "0.1", default-features = false, features = ["extended"] }
 simd-csv = "0.10.3"
 timely_bytes = { version = "0.29", path = "../timely-dataflow/bytes" }
 timely_communication = { version = "0.29", path = "../timely-dataflow/communication" }

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -1204,39 +1204,34 @@ pub mod layers {
 
         // We want to mint a new item for each distinct (group, value).
         // We want to seal a new list for each distinct group.
-        let mut pages_iter = pages.iter_mut().filter(|p| !p.is_empty());
+        // Fused: scatter `groups[i] = new_group_index` inline rather than overwriting
+        // the page's group byte and re-iterating in a second pass. This both removes
+        // a full pass over the data and lets us drain pages (peak memory shrinks
+        // monotonically as the loop advances).
+        let mut pages_iter = pages.drain(..).filter(|p| !p.is_empty());
         if let Some(first_page) = pages_iter.next() {
-            let triples = first_page.as_mut_slice().as_flattened_mut().as_chunks_mut::<4>().0.as_chunks_mut::<3>().0;
-            let mut iter = triples.iter_mut();
-            let [group, value, _] = iter.next().expect("non-empty page has at least one row");
+            let triples = first_page.as_slice().as_flattened().as_chunks::<4>().0.as_chunks::<3>().0;
+            let mut iter = triples.iter();
+            let [group, value, i] = iter.next().expect("non-empty page has at least one row");
             output.values.push(*value);
             let mut prev = (*group, *value);
-            *group = 0u32.to_be_bytes();
-            for [group, value, _] in iter {
+            groups[u32::from_be_bytes(*i) as usize] = 0;
+            for [group, value, i] in iter {
                 if prev.0 != *group { output.bounds.push(output.values.len() as u64); }
                 if prev != (*group, *value) { output.values.push(*value); }
                 prev = (*group, *value);
-                *group = ((output.values.len() - 1) as u32).to_be_bytes();
+                groups[u32::from_be_bytes(*i) as usize] = output.values.len() - 1;
             }
             for page in pages_iter {
-                let triples = page.as_mut_slice().as_flattened_mut().as_chunks_mut::<4>().0.as_chunks_mut::<3>().0;
-                for [group, value, _] in triples.iter_mut() {
+                let triples = page.as_slice().as_flattened().as_chunks::<4>().0.as_chunks::<3>().0;
+                for [group, value, i] in triples.iter() {
                     if prev.0 != *group { output.bounds.push(output.values.len() as u64); }
                     if prev != (*group, *value) { output.values.push(*value); }
                     prev = (*group, *value);
-                    *group = ((output.values.len() - 1) as u32).to_be_bytes();
+                    groups[u32::from_be_bytes(*i) as usize] = output.values.len() - 1;
                 }
             }
             output.bounds.push(output.values.len() as u64);
-        }
-
-        // Sorting is optional, and could improve performance for large, disordered lists, or cost otherwise.
-        // If we retained the pages and allocation from the previous invocation it might be faster.
-        for page in pages.iter() {
-            let triples = page.as_slice().as_flattened().as_chunks::<4>().0.as_chunks::<3>().0;
-            for [g, _, i] in triples.iter() {
-                groups[u32::from_be_bytes(*i) as usize] = u32::from_be_bytes(*g) as usize;
-            }
         }
 
         output
@@ -1267,7 +1262,9 @@ pub mod layers {
 
         // We want to mint a new item for each distinct (group, value).
         // We want to seal a new list for each distinct group.
-        let mut pages_iter = pages.iter().filter(|p| !p.is_empty());
+        // Drain pages as we consume them so the input memory drops monotonically
+        // while `output` grows; peak ~= max(input, output) rather than their sum.
+        let mut pages_iter = pages.drain(..).filter(|p| !p.is_empty());
         if let Some(first_page) = pages_iter.next() {
             let pairs = first_page.as_slice().as_flattened().as_chunks::<4>().0.as_chunks::<2>().0;
             let mut iter = pairs.iter();

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -1204,31 +1204,28 @@ pub mod layers {
 
         // We want to mint a new item for each distinct (group, value).
         // We want to seal a new list for each distinct group.
-        // Fused: scatter `groups[i] = new_group_index` inline rather than overwriting
-        // the page's group byte and re-iterating in a second pass. This both removes
-        // a full pass over the data and lets us drain pages (peak memory shrinks
-        // monotonically as the loop advances).
+        // We want to update groups with index as we go (random access potentially pessimal).
         let mut pages_iter = pages.drain(..).filter(|p| !p.is_empty());
         if let Some(first_page) = pages_iter.next() {
             let triples = first_page.as_slice().as_flattened().as_chunks::<4>().0.as_chunks::<3>().0;
             let mut iter = triples.iter();
-            let [group, value, i] = iter.next().expect("non-empty page has at least one row");
+            let [group, value, index] = iter.next().expect("non-empty page has at least one row");
             output.values.push(*value);
             let mut prev = (*group, *value);
-            groups[u32::from_be_bytes(*i) as usize] = 0;
-            for [group, value, i] in iter {
+            groups[u32::from_be_bytes(*index) as usize] = 0;
+            for [group, value, index] in iter {
                 if prev.0 != *group { output.bounds.push(output.values.len() as u64); }
                 if prev != (*group, *value) { output.values.push(*value); }
                 prev = (*group, *value);
-                groups[u32::from_be_bytes(*i) as usize] = output.values.len() - 1;
+                groups[u32::from_be_bytes(*index) as usize] = output.values.len() - 1;
             }
             for page in pages_iter {
                 let triples = page.as_slice().as_flattened().as_chunks::<4>().0.as_chunks::<3>().0;
-                for [group, value, i] in triples.iter() {
+                for [group, value, index] in triples.iter() {
                     if prev.0 != *group { output.bounds.push(output.values.len() as u64); }
                     if prev != (*group, *value) { output.values.push(*value); }
                     prev = (*group, *value);
-                    groups[u32::from_be_bytes(*i) as usize] = output.values.len() - 1;
+                    groups[u32::from_be_bytes(*index) as usize] = output.values.len() - 1;
                 }
             }
             output.bounds.push(output.values.len() as u64);

--- a/src/main.rs
+++ b/src/main.rs
@@ -339,13 +339,13 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                     state.comms.broadcast(&mut empty);
                 }
                 ".time" => {
-                    println!("time:\t{:?}\t{:?}", timer.elapsed(), words.collect::<Vec<_>>());
+                    println!(".time\t{:?}\t{:?}", timer.elapsed(), words.collect::<Vec<_>>());
                     *timer = std::time::Instant::now();
                 }
                 ".heap" => {
                     let h = heap_info();
                     println!(
-                        "heap:\trss={} peak_rss={} commit={} peak_commit={}\t{:?}",
+                        ".heap\trss={} peak_rss={} commit={} peak_commit={}\t{:?}",
                         fmt_bytes(h.rss), fmt_bytes(h.peak_rss),
                         fmt_bytes(h.commit), fmt_bytes(h.peak_commit),
                         words.collect::<Vec<_>>(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,37 @@ use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
+/// Snapshot of process memory stats from mimalloc's `mi_process_info`.
+struct HeapInfo { rss: usize, peak_rss: usize, commit: usize, peak_commit: usize }
+
+fn heap_info() -> HeapInfo {
+    let mut v = [0usize; 8];
+    // SAFETY: `mi_process_info` writes to eight `usize` out-parameters and
+    // performs no other observable effects.
+    unsafe {
+        libmimalloc_sys::mi_process_info(
+            &mut v[0], &mut v[1], &mut v[2],
+            &mut v[3], &mut v[4], &mut v[5], &mut v[6], &mut v[7],
+        );
+    }
+    HeapInfo { rss: v[3], peak_rss: v[4], commit: v[5], peak_commit: v[6] }
+}
+
+fn fmt_bytes(n: usize) -> String {
+    // mimalloc tracks `current_commit` as a signed delta (commits minus
+    // purges to the OS) and stores it in a usize; if it goes negative it
+    // wraps near usize::MAX. Reinterpret as isize so negatives print as
+    // signed values instead of nonsense like "16777215.99TiB".
+    const UNITS: [&str; 5] = ["B", "KiB", "MiB", "GiB", "TiB"];
+    let signed = n as isize;
+    let mag = signed.unsigned_abs();
+    let mut x = mag as f64;
+    let mut u = 0;
+    while x >= 1024.0 && u + 1 < UNITS.len() { x /= 1024.0; u += 1; }
+    let sign = if signed < 0 { "-" } else { "" };
+    if u == 0 { format!("{}{}B", sign, mag) } else { format!("{}{:.2}{}", sign, x, UNITS[u]) }
+}
+
 fn main() {
 
     use timely_communication::Config;
@@ -310,6 +341,15 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                 ".time" => {
                     println!("time:\t{:?}\t{:?}", timer.elapsed(), words.collect::<Vec<_>>());
                     *timer = std::time::Instant::now();
+                }
+                ".heap" => {
+                    let h = heap_info();
+                    println!(
+                        "heap:\trss={} peak_rss={} commit={} peak_commit={}\t{:?}",
+                        fmt_bytes(h.rss), fmt_bytes(h.peak_rss),
+                        fmt_bytes(h.commit), fmt_bytes(h.peak_commit),
+                        words.collect::<Vec<_>>(),
+                    );
                 }
                 ".decl" => {
                     // `.decl name(_, _, ...) [flags]` declares a relation's arity and any


### PR DESCRIPTION
Release memory as it is consumed, while forming layer outputs in various sorting routines. It turns out this doesn't actively help a lot, in that the paged nature of allocation seems that they come from and would return to very different mimalloc size classes; the output allocations are larger and chunkier. The second commit adds a `.heap` directive for mimalloc inspection.