### PR TITLE
Fix `:times` divide-by-zero and wasm-unsafe index encoding

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -57,7 +57,11 @@ impl Comms {
         if !indices.is_empty() {
             let mut column = Terms::default();
             for index in indices.iter() {
-                column.push(&index.to_be_bytes().to_vec());
+                // Encode width-independently as `u64`: `usize::to_be_bytes` is 8
+                // bytes on 64-bit targets but 4 on wasm32, and the decode below
+                // matches on `len() == 8`. A bare `usize` here silently drops
+                // every index on wasm32, collapsing the fixpoint to one round.
+                column.push(&(*index as u64).to_be_bytes().to_vec());
             }
             if let Some(forest) = Forest::from_columns(vec![column]) {
                 facts.extend([forest]);
@@ -70,7 +74,7 @@ impl Comms {
             for i in 0 .. flat.layer(0).list.values.len() {
                 let bytes = flat.layer(0).list.values.borrow().get(i).as_slice();
                 if bytes.len() == 8 {
-                    indices.insert(usize::from_be_bytes(bytes.try_into().unwrap()));
+                    indices.insert(u64::from_be_bytes(bytes.try_into().unwrap()) as usize);
                 }
             }
         }

--- a/src/rules/atoms/logic.rs
+++ b/src/rules/atoms/logic.rs
@@ -368,7 +368,7 @@ pub mod relations {
                     [Some(x), None,    Some(z)] => { if x > 0 && x <= z && (z / x) * x == z { output.1.push(&(z/x).to_be_bytes()[(8-width)..]) } },
                     // If we only have z, we there are only so many products that can form `z`.
                     [None,    None,    Some(z)] => {
-                        for i in 0 .. z.isqrt()+1 {
+                        for i in 1 .. z.isqrt()+1 {
                             if (z / i) * i == z { output.1.push(&i.to_be_bytes()[(8-width)..]); }
                         }
                     },


### PR DESCRIPTION
The :times divisor mode (_, _, z) looped from i = 0, dividing by zero on the first iteration whenever it fired.

comms.rs encoded broadcast indices with usize::to_be_bytes, which is four bytes on wasm32 while the decoder matches on len() == 8, silently dropping every index and collapsing the fixpoint to one round. Encode as u64 for a width-independent representation.