### PR TITLE
Planner: generous proposers + stage-0 seed semijoin reduction

### DIFF
--- a/scripts/remy.dt
+++ b/scripts/remy.dt
@@ -1,0 +1,21 @@
+.note remy.dt — the chain-join intermediate-blowup query (from Remy Wang).
+.note A worst-case-optimal plan that lets T semijoin-prune y before fanning out the independent w dimension keeps the intermediate bounded.
+.note This is a canary: it runs fine today, and explodes to a 1T intermediate the moment the planner regresses to a binary-join-first shape.
+
+.time reset
+
+R(0, 0) :- .
+R(x, 999999) :- :range(1, x, 1000000).
+S(x, 0) :- :range(0, x, 999999).
+S(999999, x) :- :range(1, x, 1000000).
+T(0, x) :- :range(0, x, 999999).
+T(999999, 999999) :- .
+.time inputs built
+
+Q(w,x,y,z) :- R(w,x), S(x,y), T(y,z).
+.time Q complete
+
+.list
+.test Q 1999998
+
+.quit

--- a/src/rules/atoms/view.rs
+++ b/src/rules/atoms/view.rs
@@ -177,9 +177,11 @@ fn build_join_apparatus(
     // If sum is the sole atom in this stage, it acts as the proposer (count protocol
     // short-circuits to atom.join with terms). Pattern is sum's terms minus what this
     // stage introduces. Otherwise sum is a validator and all of sum's terms are bound
-    // by the time `join` is called.
+    // by the time `join` is called. Stage 0 is excluded from the proposer case: it is
+    // run with empty `terms`, so even a sole atom there is a semijoin (introduces
+    // nothing), and its bound pattern is the terms it shares with the seed.
     let pattern: BTreeSet<String> =
-        if stage_atoms.len() == 1 && stage_atoms.contains(&load_atom) {
+        if stage_idx != 0 && stage_atoms.len() == 1 && stage_atoms.contains(&load_atom) {
             load_terms_set.difference(&stage_terms_to_intro).cloned().collect()
         } else {
             let mut all_bound = bound_at_stage.clone();

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -267,10 +267,22 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
         .cloned()
         .filter(|t| terms_to_atoms.contains_key(t) || need.contains(t))
         .collect();
-    // Body atoms whose terms are all already in `init_terms` should be present in stage 0.
+    // Stage-0 atoms semijoin-reduce the seed (see the `Plan` doc: "the atoms of the
+    // first stage intersect these terms, but they may not fully span it"). Two ways in:
+    //   - fully covered: every term is bound, a pure semijoin on all of them (this is
+    //     also how anti atoms participate — a complete antijoin);
+    //   - partial: the atom shares a bound term AND can `ground` from the bound set, so
+    //     it constrains the seed on the shared prefix. The `ground` check is what keeps
+    //     this sound: a pure filter (anti, equality predicate) grounds nothing, so it
+    //     can only enter fully covered, never on a strict subset.
     let init_atoms: BTreeSet<A> =
     body.iter()
-        .filter(|(_, boxed)| boxed.terms().iter().all(|t| init_terms.contains(t)))
+        .filter(|(_, boxed)| {
+            let terms = boxed.terms();
+            terms.iter().all(|t| init_terms.contains(t))
+            || (terms.iter().any(|t| init_terms.contains(t))
+                && !boxed.ground(&init_terms).is_empty())
+        })
         .map(|(a, _)| *a)
         .collect();
 
@@ -325,7 +337,13 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
 
     // Fuse adjacent stages with the same single-atom set: the same atom introducing
     // multiple consecutive variables is one stage, not several.
-    for index in (1 .. plan.len()).rev() {
+    // Start at index 2: a fusion target must itself be an *introducing* stage. Stage 0
+    // is the seed stage — its atoms semijoin the seed rather than introduce its terms —
+    // so it is never a fusion target, else its introduced-nothing would absorb a real
+    // term and the executor (which runs stage 0 with empty `terms`) would drop it. We
+    // can't defer this to `ground`: at the seed boundary nothing is bound, so `ground`
+    // is cross-join-optimistic and can't distinguish the seed stage.
+    for index in (2 .. plan.len()).rev() {
         if plan[index].0 == plan[index-1].0 && plan[index].0.len() == 1 {
             let stage = plan.remove(index);
             plan[index-1].1.extend(stage.1);

--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -297,21 +297,14 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
             .next());
 
         if let Some(next_term) = next_term {
-            // Atoms that ground `next_term` AND share at least one already-bound term:
-            // these are real (non-cross-product) participants.
-            let constrained: BTreeSet<A> = body.iter()
-                .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term)
-                    && terms.iter().any(|t| boxed.terms().contains(t)))
+            // Generous: any atom that can ground `next_term` participates in this stage,
+            // independent of whether it shares an already-bound term. Atoms with no bound
+            // term in common still semijoin on `next_term`, intersecting its candidate
+            // values here rather than deferring the constraint to a later stage.
+            let mut next_atoms: BTreeSet<A> = body.iter()
+                .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term))
                 .map(|(a, _)| *a)
                 .collect();
-            // Fall back to any atom grounding `next_term` (including cross-product
-            // candidates) only when no constrained atoms exist for this term.
-            let mut next_atoms = constrained;
-            if next_atoms.is_empty() {
-                next_atoms.extend(body.iter()
-                    .filter(|(_a, boxed)| boxed.ground(&terms).contains(&next_term))
-                    .map(|(a, _)| *a));
-            }
             if next_atoms.is_empty() {
                 next_atoms = terms_to_atoms[&next_term].iter()
                     .filter(|a| body[a].terms().contains(&next_term))


### PR DESCRIPTION
## What

Two planner changes, one commit each.

**1. Generalize stage proposers to all grounding atoms.** At each term-introduction stage, every atom that can `ground` the new term participates as a proposer (the runtime count race chooses among them), rather than only atoms that *also* share an already-bound term. Cross-join candidates semijoin on the new term in-stage instead of deferring the constraint to a later stage.

**2. Semijoin-reduce the seed at stage 0.** Atoms that share a bound seed term and can `ground` from it now reduce the seed at stage 0 — per the `Plan` doc, stage-0 atoms "intersect these terms, but they may not fully span it" — pruning the seed before later stages fan it out. An incremental change arriving on the middle atom of a chain join no longer materializes a quadratic intermediate. Soundness follows from `ground`: a pure filter (anti atom, equality predicate) grounds nothing, so it can only ever participate fully-covered, never on a strict subset. This newly reaches two latent issues, fixed here: the stage fuse no longer folds a term-introducing stage into the seed stage (which is run with empty `terms` and would drop the term), and the view join apparatus treats a stage-0 sole atom as a semijoin rather than a proposer (so its bound pattern is the terms it shares with the seed). Adds `scripts/remy.dt`, a chain-join canary whose intermediate blows up quadratically if the seed isn't reduced.

## Benchmarks (mini-03, single-node, M4 / 16 GB)

| workload | main | this PR | Δ |
|---|---|---|---|
| batik | 296.5s | 160.2s | **−46%** |
| cspa-linux | 8.42s | 8.94s | +6.2% |
| cspa-alt | 19.80s | 20.45s | +3.3% |

All golden `.test`s pass; the self-contained script suite is byte-identical to `main` apart from benign maintained-arrangement labels.

**This is a trade, stated plainly:** a large win on batik-shaped rules against a ~6% regression on the cspa points-to shape. Attribution (3-repeat medians): on cspa-linux the generous-proposer change costs +14.7% and the stage-0 change recovers it to +6.2%; on cspa-alt generous is ~neutral and stage-0 adds the +3% (no-prune semijoin cost). The regression is the documented generous-inclusion cost — flipping a stage from the single-proposer fast path into the WCO ceremony. Cost-gated inclusion (skip the flip / semijoin only where it is expected to prune) is the follow-up that would recover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)