### PR TITLE
Make book and README examples runnable in the browser demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ tri(a, b, c) :- arc(a,b), arc(b,c), arc(c,a).
 For me, this loads the data in ~100ms, and enumerates all triangles in an additional 1s.
 Also for me, the PostgreSQL query is still running five minutes later, and has spun up two additional helper processes to help max out my CPUs.
 
+> **▶ Try it in your browser.** Paste the `datatoad` block above into the [live demo](http://www.frankmcsherry.org/datatoad/demo/). It builds a few million facts in single-threaded WebAssembly, so it runs slower than the native ~1s and pauses the page while it works.
+
 ### Predicates as Relations
 
 You may have noticed the `:range` and `:plus` above, and wondered what they represent?

--- a/mdbook/src/chapter_0/chapter_0_1.md
+++ b/mdbook/src/chapter_0/chapter_0_1.md
@@ -7,9 +7,9 @@ A Datalog program consists of *facts* (things that are true) and *rules* (ways t
 For example, given edges in a graph:
 
 ```
-edge(1, 2).
-edge(2, 3).
-edge(3, 4).
+edge(1, 2) :- .
+edge(2, 3) :- .
+edge(3, 4) :- .
 ```
 
 We can define reachability:
@@ -24,6 +24,8 @@ The second says: if there is an edge from `x` to `z`, and `y` is reachable from 
 
 The engine computes the fixpoint: it repeatedly applies the rules until no new facts are derived.
 The result is every `(x, y)` pair where `y` is reachable from `x`.
+
+> **▶ Try it.** Paste the facts and rules above into the [browser demo](../demo/), then run `.list` to see the derived `reach` relation. (Facts are written `edge(1, 2) :- .` — a rule with an empty body.)
 
 ## Incremental Datalog
 

--- a/mdbook/src/chapter_0/chapter_0_3.md
+++ b/mdbook/src/chapter_0/chapter_0_3.md
@@ -6,15 +6,17 @@ If you would like it to go faster, you can use cargo's `--release` flag.
 Let's compute transitive closure of a small graph:
 
 ```
-> edge(1, 2) :- .
-> edge(2, 3) :- .
-> edge(3, 1) :- .
+edge(1, 2) :- .
+edge(2, 3) :- .
+edge(3, 1) :- .
 
-> reach(x, y) :- edge(x, y).
-> reach(x, y) :- edge(x, z), reach(z, y).
+reach(x, y) :- edge(x, y).
+reach(x, y) :- edge(x, z), reach(z, y).
 ```
 
 Datatoad evaluates the rules to a fixpoint, and then returns a prompt.
+
+> **▶ Try it.** This whole page is a REPL session you can replay in the [browser demo](../demo/): paste the block above, then follow along with `.list` and `:print` below.
 
 The `.list` command prints all relations and their sizes.
 You should see something like

--- a/mdbook/src/chapter_0/chapter_0_3.md
+++ b/mdbook/src/chapter_0/chapter_0_3.md
@@ -16,7 +16,7 @@ reach(x, y) :- edge(x, z), reach(z, y).
 
 Datatoad evaluates the rules to a fixpoint, and then returns a prompt.
 
-> **▶ Try it.** This whole page is a REPL session you can replay in the [browser demo](../demo/): paste the block above, then follow along with `.list` and `:print` below.
+> **▶ Try it.** Paste the block above into the [browser demo](../demo/) and run `.list` to see the result; the `:print` query below works there too.
 
 The `.list` command prints all relations and their sizes.
 You should see something like

--- a/mdbook/src/chapter_0/chapter_0_4.md
+++ b/mdbook/src/chapter_0/chapter_0_4.md
@@ -25,6 +25,8 @@ tri(a, b, c) :- arc(a,b), arc(b,c), arc(c,a).
 Datatoad handles this in about a second.
 A worst-case optimal join avoids the intermediate blowup entirely: for each `(a,b)` it finds the `c` by intersecting values from `arc(b,c)` and `arc(c,a)` efficiently, and similarly for the other edge inputs.
 
+> **▶ Try it.** Paste both blocks above into the [browser demo](../demo/). This one is heavy — it builds a few million `arc` facts, and the demo runs single-threaded WebAssembly, so it takes noticeably longer than the ~1s above and pauses the page while it runs.
+
 For comparison, the equivalent SQL
 ```sql
 select count(*)


### PR DESCRIPTION
Follows the demo (#61) and book links (#62): turns the chapter-0 examples into things a reader can paste straight into the live demo.

- **`chapter_0_1`** — facts were written in textbook form (`edge(1, 2).`), which the REPL/reactor *Parse-fails*. Rewritten to `edge(1, 2) :- .` (a rule with an empty body), so the page actually runs.
- **`chapter_0_3`** — stripped the `>` prompts from the input block so the copy button yields paste-runnable text.
- **"Try it" links** on `chapter_0_1`/`0_3`/`0_4` pointing at `../demo/` (resolves to `/datatoad/demo/`), with a heavy-example caveat on the million-edge triangle (single-threaded wasm pauses the page).

All three verified to render `href="../demo/"` via a local mdbook build, and the transitive-closure example confirmed to evaluate (`3 edge`, `9 reach`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)