### PR TITLE
Add .save / .load directives backed by mmap'd columnar Stash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-columnar = "0.12"
+columnar = { git = "https://github.com/frankmcsherry/columnar" }
+memmap2 = "0.9"
 getopts = { version = "0.2.24" }
 regex = "1.11.1"
 mimalloc = { version = "0.1.48", features = ["v3"], optional = true }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -70,9 +70,8 @@ impl Comms {
         indices.clear();
         self.broadcast(&mut facts);
         if let Some(flat) = facts.flatten() {
-            use columnar::Borrow;
-            for i in 0 .. flat.layer(0).list.values.len() {
-                let bytes = flat.layer(0).list.values.borrow().get(i).as_slice();
+            for i in 0 .. flat.layer(0).list.borrow().values.len() {
+                let bytes = flat.layer(0).list.borrow().values.get(i).as_slice();
                 if bytes.len() == 8 {
                     indices.insert(u64::from_be_bytes(bytes.try_into().unwrap()) as usize);
                 }
@@ -96,7 +95,7 @@ impl Comms {
 
             while countdown > 0 {
                 comms.receive();
-                while let Some(message) = receiver.recv() { if let Some(fact) = message.facts { facts.push(fact.into_iter().map(|l| std::rc::Rc::new(Layer { list: l })).collect::<Vec<_>>().try_into().unwrap()); } countdown -= 1; }
+                while let Some(message) = receiver.recv() { if let Some(fact) = message.facts { facts.push(fact.into_iter().map(|list| std::rc::Rc::new(Layer { list })).collect::<Vec<_>>().try_into().unwrap()); } countdown -= 1; }
                 comms.release();
             }
         }
@@ -133,9 +132,8 @@ impl Comms {
         self.broadcast(&mut facts);
         let mut total: u64 = 0;
         if let Some(flat) = facts.flatten() {
-            use columnar::Borrow;
-            for i in 0 .. flat.layer(0).list.values.len() {
-                let bytes = flat.layer(0).list.values.borrow().get(i).as_slice();
+            for i in 0 .. flat.layer(0).list.borrow().values.len() {
+                let bytes = flat.layer(0).list.borrow().values.get(i).as_slice();
                 if bytes.len() == 16 {
                     total += u64::from_be_bytes(bytes[8..].try_into().unwrap());
                 }
@@ -193,7 +191,7 @@ impl Channel {
         if let Some(facts) = facts.flatten() {
             let mut bools: std::collections::VecDeque<bool> = Default::default();
             for (index, sender) in self.sends.iter_mut().enumerate() {
-                bools.extend((0 .. facts.layer(0).list.values.len()).map(|i| (*facts.layer(0).list.values.borrow().get(i).as_slice().last().unwrap() as usize) % comms.peers() == index));
+                bools.extend((0 .. facts.layer(0).list.borrow().values.len()).map(|i| (*facts.layer(0).list.borrow().values.get(i).as_slice().last().unwrap() as usize) % comms.peers() == index));
                 if let Some(facts) = facts.clone().retain_core(1, bools.clone()).flatten() {
                     let layers = (0 .. facts.arity()).map(|i| facts.layer(i).clone()).collect::<Vec<_>>();
                     drop(facts);
@@ -209,7 +207,7 @@ impl Channel {
         // Receive data first, to allow early consolidation.
         while let Some(message) = self.recv.recv() {
             if let Some(fact) = message.facts {
-                facts.push(fact.into_iter().map(|l| std::rc::Rc::new(Layer { list: l })).collect::<Vec<_>>().try_into().unwrap());
+                facts.push(fact.into_iter().map(|list| std::rc::Rc::new(Layer { list })).collect::<Vec<_>>().try_into().unwrap());
             }
             else { self.count -= 1; }
         }
@@ -252,9 +250,9 @@ impl Conduit {
 ///
 /// The encoding is first the number of columns plus one, with zero indicating `None`.
 /// The columns are then appended.
-struct FactMessage { facts: Option<Vec<Lists<Terms>>> }
+struct FactMessage { facts: Option<Vec<columnar::bytes::stash::Stash<Lists<Terms>, timely_bytes::arc::Bytes>>> }
 
-use columnar::{Borrow, Container, Index, Len, bytes::{indexed, stash::Stash}};
+use columnar::{Index, Len, bytes::{indexed, stash::Stash}};
 
 impl Bytesable for FactMessage {
     fn from_bytes(mut bytes: timely_bytes::arc::Bytes) -> Self {
@@ -266,9 +264,7 @@ impl Bytesable for FactMessage {
                 let stash: Stash<Lists<Terms>, timely_bytes::arc::Bytes> = Stash::try_from_bytes(bytes.clone()).unwrap();
                 let length = stash.length_in_bytes();
                 let _ = bytes.extract_to(length);
-                let mut column: Lists<Terms> = Default::default();
-                column.extend_from_self(stash.borrow(), 0 .. stash.len());
-                columns.push(column);
+                columns.push(stash);
             }
             FactMessage { facts: Some(columns) }
         }

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -7,10 +7,12 @@ use columnar::primitive::offsets::Strides;
 
 use crate::types::Action;
 
+pub mod store;
 pub mod trie;
 
 /// A `Vecs` using strided offsets.
 pub type Lists<C> = Vecs<C, Strides>;
+
 /// Use the `List` type to access an alternate columnar container.
 pub type Terms = Lists<Vec<u8>>;
 

--- a/src/facts/store.rs
+++ b/src/facts/store.rs
@@ -1,0 +1,160 @@
+//! On-disk persistence for fact collections.
+//!
+//! ```text
+//! <dir>/<name>/identity/
+//!   lsm_<i>/
+//!     layer_<j>.bin
+//! ```
+//!
+//! One file per trie column; each file holds a single columnar-encoded
+//! `Stash<Lists<Terms>, Bytes>`. The `recent` slot (if present) is written
+//! as the trailing `lsm_<i>` directory.
+
+
+use std::path::Path;
+use std::rc::Rc;
+
+use crate::facts::trie::Layer;
+use crate::facts::{FactCollection, FactSet, Lists, Terms};
+
+/// Writes `facts.stable` and `facts.recent` under `<dir>/<name>/identity/`.
+/// Returns the number of layer directories written. The write is staged
+/// through a sibling directory and renamed into place; failures leave any
+/// existing `identity/` unchanged.
+pub fn save_identity(name: &str, dir: &Path, facts: &FactSet<FactCollection>) -> std::io::Result<usize> {
+    let base = dir.join(name);
+    std::fs::create_dir_all(&base)?;
+
+    let final_root = base.join("identity");
+    let suffix = format!(
+        "{}.{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0),
+    );
+    let staging = base.join(format!(".identity.staging.{suffix}"));
+    let trash = base.join(format!(".identity.trash.{suffix}"));
+
+    let _ = std::fs::remove_dir_all(&staging);
+    std::fs::create_dir_all(&staging)?;
+
+    let result = (|| -> std::io::Result<usize> {
+        let mut index = 0;
+        for layer in facts.stable.contents() {
+            save_forest(&staging.join(format!("lsm_{:03}", index)), layer)?;
+            index += 1;
+        }
+        if let Some(recent) = facts.recent.as_ref() {
+            save_forest(&staging.join(format!("lsm_{:03}", index)), recent)?;
+            index += 1;
+        }
+        Ok(index)
+    })();
+
+    let index = match result {
+        Ok(n) => n,
+        Err(e) => {
+            // Don't leave a half-written staging dir behind on failure.
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(e);
+        }
+    };
+
+    // Commit: move old identity aside, move staging in, delete old.
+    let had_prior = final_root.exists();
+    if had_prior {
+        std::fs::rename(&final_root, &trash)?;
+    }
+    if let Err(e) = std::fs::rename(&staging, &final_root) {
+        // Best-effort rollback: try to put the old identity back so the user
+        // isn't left with no identity dir at all.
+        if had_prior {
+            let _ = std::fs::rename(&trash, &final_root);
+        }
+        let _ = std::fs::remove_dir_all(&staging);
+        return Err(e);
+    }
+    if had_prior {
+        let _ = std::fs::remove_dir_all(&trash);
+    }
+    Ok(index)
+}
+
+fn save_forest(dir: &Path, forest: &FactCollection) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    for j in 0..forest.arity() {
+        save_layer(&dir.join(format!("layer_{:03}.bin", j)), forest.layer(j))?;
+    }
+    Ok(())
+}
+
+fn save_layer(path: &Path, layer: &Layer<Terms>) -> std::io::Result<()> {
+    let mut f = std::fs::File::create(path)?;
+    layer
+        .list
+        .write_bytes(&mut f)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("write_bytes: {e:?}")))
+}
+
+/// Inverse of [`save_identity`]. Returns the recovered LSM layers, one
+/// `Forest<Terms>` per `lsm_<i>` directory, sorted by directory name.
+pub fn load_identity(name: &str, dir: &Path) -> std::io::Result<Vec<FactCollection>> {
+    let root = dir.join(name).join("identity");
+    if !root.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("identity directory not found: {}", root.display()),
+        ));
+    }
+
+    let mut lsm_dirs: Vec<std::path::PathBuf> = std::fs::read_dir(&root)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    lsm_dirs.sort();
+
+    let mut out = Vec::with_capacity(lsm_dirs.len());
+    for lsm_dir in lsm_dirs {
+        out.push(load_forest(&lsm_dir)?);
+    }
+    Ok(out)
+}
+
+fn load_forest(dir: &Path) -> std::io::Result<FactCollection> {
+    let mut layer_files: Vec<std::path::PathBuf> = std::fs::read_dir(dir)?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.is_file() && p.extension().is_some_and(|ext| ext == "bin"))
+        .collect();
+    layer_files.sort();
+
+    let mut layers: Vec<Rc<Layer<Terms>>> = Vec::with_capacity(layer_files.len());
+    for layer_file in layer_files {
+        let list = mmap_layer(&layer_file)?;
+        layers.push(Rc::new(Layer { list }));
+    }
+    layers.try_into().map_err(|_| std::io::Error::new(
+        std::io::ErrorKind::InvalidData,
+        "loaded layers fail Forest::try_from invariants",
+    ))
+}
+
+/// mmap a layer file as a `Stash::Bytes`. Empty files become an empty
+/// `Stash::Typed` since `mmap` requires `len > 0`.
+fn mmap_layer(path: &Path) -> std::io::Result<columnar::bytes::stash::Stash<Lists<Terms>, timely_bytes::arc::Bytes>> {
+    let file = std::fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    if len == 0 {
+        return Ok(columnar::bytes::stash::Stash::Typed(Default::default()));
+    }
+    // SAFETY: map_copy is private (writes don't propagate back) and we never
+    // write through the mapping; the only path that would (`make_typed`)
+    // replaces the variant before any byte is touched.
+    let mmap = unsafe { memmap2::MmapOptions::new().map_copy(&file)? };
+    let bytes = timely_bytes::arc::BytesMut::from(mmap).freeze();
+    columnar::bytes::stash::Stash::try_from_bytes(bytes)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -17,7 +17,7 @@
 //! the extracted column of values (forming runs of sorted values for prefixes).
 
 use std::rc::Rc;
-use columnar::{Borrow, Container, Len};
+use columnar::{Borrow, Len};
 use crate::facts::Lists;
 
 /// A non-empty collection of facts, represented as a trie with one layer per term.
@@ -32,16 +32,16 @@ use crate::facts::Lists;
 /// To represent an optionally empty collection consider an `Option<Forest<C>>` or
 /// a `FactLSM<Forest<C>>`.
 #[derive(Clone, Debug)]
-pub struct Forest<C> { layers: Vec<Rc<Layer<C>>> }
+pub struct Forest<C: columnar::ContainerBytes> { layers: Vec<Rc<Layer<C>>> }
 
-impl<C: Container> Forest<C> {
+impl<C: columnar::ContainerBytes> Forest<C> {
 
     /// The number of columns of facts in the collection.
     pub fn arity(&self) -> usize { self.layers.len() }
     /// A reference to the indexed layer.
     pub fn layer(&self, index: usize) -> &Rc<Layer<C>> { &self.layers[index] }
     /// The number of facts in the collection.
-    pub fn len(&self) -> usize { self.layers.last().map(|l| l.list.values.len()).unwrap_or(1) }
+    pub fn len(&self) -> usize { self.layers.last().map(|l| l.list.borrow().values.len()).unwrap_or(1) }
     /// A collection of borrowed containers.
     pub fn borrow<'a>(&'a self) -> Vec<<Lists<C> as Borrow>::Borrowed<'a>> {
         self.layers.iter().map(|x| x.list.borrow()).collect::<Vec<_>>()
@@ -61,7 +61,7 @@ impl<C: Container> Forest<C> {
     pub fn truncate(&mut self, arity: usize) { while self.arity() > arity { self.pop_layer(); } }
 }
 
-impl<C: Container> TryFrom<Vec<Rc<Layer<C>>>> for Forest<C> {
+impl<C: columnar::ContainerBytes> TryFrom<Vec<Rc<Layer<C>>>> for Forest<C> {
     type Error = Vec<Rc<Layer<C>>>;
     fn try_from(layers: Vec<Rc<Layer<C>>>) -> Result<Self, Self::Error> {
         for layer in layers.iter() { if layer.borrow().is_empty() { return Err(layers); } }
@@ -70,12 +70,12 @@ impl<C: Container> TryFrom<Vec<Rc<Layer<C>>>> for Forest<C> {
     }
 }
 
-impl<C: Container> crate::facts::Arity for Forest<C> {
+impl<C: columnar::ContainerBytes> crate::facts::Arity for Forest<C> {
     fn arity(&self) -> usize { self.arity() }
 }
 
 /// Advances pairs of lower and upper bounds on lists through each presented layer, to lower and upper bounds on items.
-pub fn advance_bounds<C: Container>(layers: &[<Lists<C> as Borrow>::Borrowed<'_>], bounds: &mut[(usize, usize)]) {
+pub fn advance_bounds<C: columnar::ContainerBytes>(layers: &[<Lists<C> as Borrow>::Borrowed<'_>], bounds: &mut[(usize, usize)]) {
     for layer in layers.iter() { crate::facts::trie::layers::advance_bounds::<C>(*layer, bounds); }
 }
 
@@ -85,9 +85,11 @@ pub fn advance_bounds<C: Container>(layers: &[<Lists<C> as Borrow>::Borrowed<'_>
 /// the node forks by way of the associated list of `T`, where each
 /// child has an index that can be used in a next layer (or not!).
 #[derive(Clone, Debug, Default)]
-pub struct Layer<C> { pub list: Lists<C> }
+pub struct Layer<C: columnar::ContainerBytes> {
+    pub list: columnar::bytes::stash::Stash<Lists<C>, timely_bytes::arc::Bytes>,
+}
 
-impl<C: Container> Layer<C> {
+impl<C: columnar::ContainerBytes> Layer<C> {
     pub fn borrow(&self) -> <Lists<C> as Borrow>::Borrowed<'_> { self.list.borrow() }
 }
 
@@ -139,7 +141,7 @@ pub mod terms {
                     values: column.borrow(),
                 };
                 // TODO: Figure out how to avoid `indexs` being literally just `0 .. len`.
-                Rc::new(Layer { list: crate::facts::trie::layers::sort_terms(lists, &mut groups[..], &indexs[..], index == columns_len-1) })
+                Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(crate::facts::trie::layers::sort_terms(lists, &mut groups[..], &indexs[..], index == columns_len-1)) })
             }).collect();
             Some(layers.try_into().expect("empty columns tested earlier"))
         }
@@ -165,18 +167,18 @@ pub mod terms {
                 for col in group.iter() { if col > min { constraints.insert(*col, Ok(*min)); } }
             }
 
-            let mut active = (0 .. self.layers[0].list.values.len()).collect::<Vec<_>>();
+            let mut active = (0 .. self.layers[0].list.borrow().values.len()).collect::<Vec<_>>();
             let mut cursor = 0;
             for (col, filter) in constraints {
                 self.layers[cursor+1 .. col+1].iter().for_each(|l| {
-                    active = active.drain(..).flat_map(|i| { let (l,u) = l.list.bounds.bounds(i); l .. u}).collect::<Vec<_>>();
+                    active = active.drain(..).flat_map(|i| { let (l,u) = l.list.borrow().bounds.bounds(i); l .. u}).collect::<Vec<_>>();
                 });
                 cursor = col;
                 // `bounds` are now in terms of `col`s items.
                 match filter {
                     Ok(idx) => {
                         // naively start from all items at layer `idx`; could optimize to the active subset at the time.
-                        let mut bounds = (0 .. self.layers[idx].list.values.len()).map(|i| (i, i+1)).collect::<Vec<_>>();
+                        let mut bounds = (0 .. self.layers[idx].list.borrow().values.len()).map(|i| (i, i+1)).collect::<Vec<_>>();
                         crate::facts::trie::advance_bounds::<Terms>(&self.borrow()[idx+1..col+1], &mut bounds);
 
                         let mut active_peek = active.iter().copied().peekable();
@@ -187,7 +189,7 @@ pub mod terms {
                             std::iter::repeat(i).take(count)
                         }).collect::<Vec<_>>();
 
-                        crate::facts::trie::layers::filter_items::<Terms>(self.layers[col].borrow(), &mut active, self.layers[idx].list.values.borrow(), &aligned[..]);
+                        crate::facts::trie::layers::filter_items::<Terms>(self.layers[col].borrow(), &mut active, self.layers[idx].list.borrow().values, &aligned[..]);
                     }
                     Err(lit) => {
                         let mut literal = Lists::<Terms>::default();
@@ -199,7 +201,7 @@ pub mod terms {
             }
 
             // use `active` at `cursor` to retain lists and items.
-            let mut include = std::iter::repeat(false).take(self.layers[cursor].list.values.len()).collect::<std::collections::VecDeque<_>>();
+            let mut include = std::iter::repeat(false).take(self.layers[cursor].list.borrow().values.len()).collect::<std::collections::VecDeque<_>>();
             if active.is_empty() { return None; }
             for idx in active.iter().copied() { include[idx] = true; }
             let mut layers: Vec<Rc<_>> = Vec::new();
@@ -233,20 +235,20 @@ pub mod terms {
                         let first_pos = projection.iter().position(|c| c == &Ok(*col)).unwrap();
                         if first_pos == pos { self.layers.pop().unwrap() }
                         else {  // create a copy of this column at the end of `layers`.
-                            let mut bounds = (0 .. self.layers[*col].list.values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
+                            let mut bounds = (0 .. self.layers[*col].list.borrow().values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
                             for layer in self.layers[*col..].iter().skip(1) { crate::facts::trie::layers::advance_bounds::<Terms>(layer.borrow(), &mut bounds[..]); }
                             let mut list = Lists::<Terms>::default();
                             for (index, (lower, upper)) in bounds.into_iter().enumerate() {
-                                for _ in lower .. upper { use columnar::Push; list.push([self.layers[*col].list.values.borrow().get(index)]); }
+                                for _ in lower .. upper { use columnar::Push; list.push([self.layers[*col].list.borrow().values.get(index)]); }
                             }
-                            Rc::new(Layer { list })
+                            Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(list) })
                         }
                     },
                     Err(lit) => {
-                        let count = self.layers.last().map(|l| l.list.values.len()).unwrap_or(1);
+                        let count = self.layers.last().map(|l| l.list.borrow().values.len()).unwrap_or(1);
                         let mut list = Lists::<Terms>::default();
                         for _ in 0 .. count { use columnar::Push; list.push([lit]); }
-                        Rc::new(Layer { list })
+                        Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(list) })
                     },
                 });
             }
@@ -273,7 +275,7 @@ pub mod terms {
             for layer in 0 .. prefix {
                 let mut out_layer = <Lists::<Terms> as Container>::with_capacity_for([layers[layer]].into_iter());
                 for (lower, upper) in bounds.iter().copied() { out_layer.extend_from_self(layers[layer], lower .. upper); }
-                output.push(Rc::new(Layer { list: out_layer }));
+                output.push(Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(out_layer) }));
                 crate::facts::trie::layers::advance_bounds::<Terms>(layers[layer], &mut bounds);
             }
 
@@ -387,7 +389,7 @@ pub mod terms {
             groups_list_layer = col+1;
 
             let last = projection_idx == projection.len() - 1;
-            result.push(Rc::new(Layer { list: crate::facts::trie::layers::sort_terms(layers[col], &mut groups, &indexs, last) }));
+            result.push(Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(crate::facts::trie::layers::sort_terms(layers[col], &mut groups, &indexs, last)) }));
 
             projection_idx += 1;
 
@@ -413,7 +415,7 @@ pub mod terms {
                 indexs.extend(idents.iter().copied().flat_map(|(l,u)| l..u).zip(bounds.iter().copied().map(|(l,u)| u-l)).flat_map(|(i,c)| std::iter::repeat(i).take(c)));
 
                 let last = projection_idx == projection.len() - 1;
-                result.push(Rc::new(Layer { list: crate::facts::trie::layers::sort_terms(layers[col], &mut groups, &indexs, last) }));
+                result.push(Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(crate::facts::trie::layers::sort_terms(layers[col], &mut groups, &indexs, last)) }));
 
                 projection_idx += 1;
             }
@@ -618,7 +620,7 @@ pub mod terms {
                     expand(Rc::make_mut(&mut that_j), values, &mut others);
                     sort_terms(values, &mut groups, &that_j, last)
                 };
-                Rc::new(Layer { list })
+                Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(list) })
             }).collect::<Vec<_>>();
 
             output_lsm.push(layers.try_into().expect("non-empty intersection guarding"));
@@ -663,9 +665,10 @@ pub mod terms {
                     let mut layers = permute_subset(layers[index], projection, indexs[index], thresh);
                     let mut base: Layer<Terms> = Default::default();
                     use columnar::Push;
+                    let inner = base.list.make_typed();
                     // TODO: rework layers to allow this to be something akin to `&groups[index]` without the copy.
-                    base.list.values.extend(groups[index].iter().map(|g| (*g as u32).to_be_bytes()));
-                    base.list.bounds.push(groups[index].len() as u64);
+                    inner.values.extend(groups[index].iter().map(|g| (*g as u32).to_be_bytes()));
+                    inner.bounds.push(groups[index].len() as u64);
                     layers.insert(0, Rc::new(base));
                     extracted.layers.push(layers.try_into().expect("guarded by !groups[index].is_empty()"));
                 }
@@ -779,7 +782,7 @@ pub mod terms {
             });
 
             // First, collect reports to determine paths to retain to `self`.
-            let mut include = std::iter::repeat(!semi).take(self.layers[other_arity-1].list.values.len()).collect::<VecDeque<_>>();
+            let mut include = std::iter::repeat(!semi).take(self.layers[other_arity-1].list.borrow().values.len()).collect::<VecDeque<_>>();
             for other in others.iter() {
                 let mut reports = (vec![0], vec![0]);
                 for (layer0, layer1) in self.layers.iter().zip(other.iter()) {
@@ -797,7 +800,7 @@ pub mod terms {
         /// The bitmap is inserted between layer_index - 1 and layer_index, restricting either the items of layer_index-1 or the lists of layer_index.
         pub fn retain_core(mut self, layer_index: usize, mut include: std::collections::VecDeque<bool>) -> FactLSM<Self> {
 
-            if layer_index > 0 { assert_eq!(include.len(), self.layers[layer_index-1].list.values.len()); }
+            if layer_index > 0 { assert_eq!(include.len(), self.layers[layer_index-1].list.borrow().values.len()); }
             if layer_index < self.arity() { assert_eq!(include.len(), self.layers[layer_index].list.len()); }
 
             let aggr = include.iter().fold(0u8, |b, i| b | if *i { 1u8 } else { 2u8 });
@@ -869,16 +872,16 @@ pub mod layers {
     /// These sizes are not specifically important, but we do want to support this sort of thing.
     impl Layer<Terms> {
         /// Unions two layers, aligned through `reports`, which is refilled if `next` is set.
-        pub fn union(&self, other: &Self, reports: &mut VecDeque<Report>, next: bool) -> Self { Self { list: terms::union(self.borrow(), other.borrow(), reports, next) } }
+        pub fn union(&self, other: &Self, reports: &mut VecDeque<Report>, next: bool) -> Self { Self { list: columnar::bytes::stash::Stash::Typed(terms::union(self.borrow(), other.borrow(), reports, next)) } }
 
         /// Intersects two layers, aligned through `aligns`.
         pub fn intersection(&self, other: &Self, both0: &[usize], both1: &[usize]) -> (Vec<usize>, Vec<usize>) { terms::intersection(self.borrow(), other.borrow(), both0, both1) }
 
         /// Retains lists indicated by `retain`, which is refilled.
-        pub fn retain_lists(&self, bounds: &mut [(usize, usize)]) -> Self { Self { list: terms::retain_lists(self.borrow(), bounds) } }
+        pub fn retain_lists(&self, bounds: &mut [(usize, usize)]) -> Self { Self { list: columnar::bytes::stash::Stash::Typed(terms::retain_lists(self.borrow(), bounds)) } }
 
         /// Retains items indicated by `retain`, which is refilled.
-        pub fn retain_items(&self, retain: &mut VecDeque<bool>) -> Self { Self { list: terms::retain_items(self.borrow(), retain) } }
+        pub fn retain_items(&self, retain: &mut VecDeque<bool>) -> Self { Self { list: columnar::bytes::stash::Stash::Typed(terms::retain_items(self.borrow(), retain)) } }
     }
 
     pub mod terms {

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
                 if let Some(text) = next_command_line(&mut cmd_stack) {
                     let mut list: Lists<Terms> = Default::default();
                     list.push([text.as_bytes()]);
-                    command.push(vec![Rc::new(Layer { list })].try_into().unwrap());
+                    command.push(vec![Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(list) })].try_into().unwrap());
                 }
                 // None → leave `command` empty → broadcast tells workers to stop.
             }
@@ -168,7 +168,8 @@ fn print_help() {
     println!("  .heap [tag ...]             print resident/peak memory usage");
     println!("  .help                       show this message");
     println!("  .list                       list all known relations and their sizes");
-    println!("  .load <name> <regex> <file> ingest <file>, extracting fields via named captures");
+    println!("  .read <name> <regex> <file> ingest <file>, extracting fields via named captures");
+    println!("  .load <name> <dir>         mmap a previously .save'd relation from <dir>");
     println!("  .note ...                   no-op; comment line");
     println!("  .plan <rule>                show the planner's stage-by-stage breakdown for <rule>");
     println!("  .prof                       print per-rule (and per-seed) accumulated runtime");
@@ -203,11 +204,36 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                     else { println!(".flow command requires arguments: <name> <file>"); }
                 }
                 ".load" => {
+                    // `.load <name> <dir>` mmaps a previously `.save`d Identity
+                    // form back into the relation.
+                    let parts: Vec<&str> = words.collect();
+                    let args: Result<[_;2],_> = parts.try_into();
+                    if let Ok([name, dir]) = args {
+                        match datatoad::facts::store::load_identity(name, std::path::Path::new(dir)) {
+                            Ok(forests) => {
+                                let total: usize = forests.iter().map(|f| f.len()).sum();
+                                let arity = forests.first().map(|f| f.arity()).unwrap_or(0);
+                                let atom = crate::types::Atom { name: name.to_string(), anti: false, terms: vec![crate::types::Term::Lit(vec![]); arity] };
+                                // Loaded forests are already deduped & sorted (they were
+                                // stable LSM layers when saved). Pushing them directly to
+                                // `stable` keeps them as separate layers — no flatten over
+                                // 134 MB just to honor the to_add → recent → stable pipeline.
+                                let entry = state.facts.entry(&atom);
+                                for forest in forests { entry.stable.push(forest); }
+                                if state.comms.index() == 0 { println!(".load ok   {}: {} facts", name, total); }
+                            }
+                            Err(e) => { if state.comms.index() == 0 { println!(".load FAIL {}: {}", name, e); } }
+                        }
+                    }
+                    else { if state.comms.index() == 0 { println!(".load command requires arguments: <name> <dir>"); } }
+                }
+                ".read" => {
 
                     use std::io::{BufRead, BufReader};
                     use std::fs::File;
 
-                    let args: Result<[_;3],_> = words.take(3).collect::<Vec<_>>().try_into();
+                    let parts: Vec<&str> = words.collect();
+                    let args: Result<[_;3],_> = parts.try_into();
                     if let Ok(args) = args {
                         let name = args[0].to_string();
                         let pattern = args[1];
@@ -257,7 +283,7 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                         }
                         else { println!("invalid regex: {:?}", pattern); }
                     }
-                    else { println!(".load command requires arguments: <name> <patt> <file>"); }
+                    else { println!(".read command requires arguments: <name> <patt> <file>"); }
                 }
                 ".note" => { }
                 ".plan" => {
@@ -355,7 +381,24 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                         }
                     }
                 }
-                ".save" => { println!("unimplemented: {:?}", word); }
+                ".save" => {
+                    // `.save <name> <dir>` — write the Identity form of <name>
+                    // to disk under <dir>/<name>/identity/. Each LSM layer
+                    // (plus `recent`) becomes a numbered subdirectory; each
+                    // trie layer within that becomes a column subdirectory
+                    // of small binary blobs. Single-worker scope for now.
+                    let args: Result<[_;2],_> = words.take(2).collect::<Vec<_>>().try_into();
+                    match args {
+                        Ok([name, dir]) => match state.facts.get(name) {
+                            Some(facts) => match datatoad::facts::store::save_identity(name, std::path::Path::new(dir), facts) {
+                                Ok(n) => { if state.comms.index() == 0 { println!(".save ok   {}: {} layer(s) under {}", name, n, dir); } }
+                                Err(e) => { if state.comms.index() == 0 { println!(".save FAIL {}: {}", name, e); } }
+                            },
+                            None => { if state.comms.index() == 0 { println!(".save FAIL {}: relation does not exist", name); } }
+                        },
+                        Err(_) => { if state.comms.index() == 0 { println!(".save command requires arguments: <name> <dir>"); } }
+                    }
+                }
                 ".sync" => {
                     // Cluster-wide barrier: broadcast an empty FactLSM so every
                     // peer waits to receive from every other peer. No-op in
@@ -565,7 +608,7 @@ mod flow_log {
                 lsb_paged::<_, 1024>(&mut data, &diff[..]);
                 let iter = data.into_iter().flat_map(|page| page);
                 if let Some(layers) = build(iter) {
-                    result.push(layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: l }) ).collect::<Vec<_>>().try_into().unwrap());
+                    result.push(layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(l) }) ).collect::<Vec<_>>().try_into().unwrap());
                 }
                 counter = 0;
             }
@@ -577,7 +620,7 @@ mod flow_log {
         lsb_paged::<_, 1024>(&mut data, &diff[..]);
         let iter = data.into_iter().flat_map(|page| page);
         if let Some(layers) = build(iter) {
-            result.push(layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: l }) ).collect::<Vec<_>>().try_into().unwrap());
+            result.push(layers.into_iter().map(|l| std::rc::Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(l) }) ).collect::<Vec<_>>().try_into().unwrap());
         }
 
         result

--- a/src/rules/atoms/data.rs
+++ b/src/rules/atoms/data.rs
@@ -50,7 +50,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
         } else { None };
 
         if let Some(mut delta) = salad.facts.flatten() {
-            let length = if prefix > 0 { delta.layer(prefix-1).list.values.len() } else { 1 };
+            let length = if prefix > 0 { delta.layer(prefix-1).list.borrow().values.len() } else { 1 };
             let mut counts = vec![0; length];
             // We may have a count override; if so, just apply it.
             if let Some(g) = global_zero_count { counts[0] = g; }
@@ -94,7 +94,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
                 }
                 for index in (0 .. prefix).rev() { layers.insert(0, Rc::new(delta.layer(index).retain_items(&mut bools))); }
 
-                assert_eq!(counts.len(), layers[prefix-1].list.values.len());
+                assert_eq!(counts.len(), layers[prefix-1].list.borrow().values.len());
                 delta = layers.try_into().expect("non-empty due to count.is_empty() guard");
             }
 
@@ -103,7 +103,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
             for layer in prefix .. delta.arity() { advance_bounds::<Terms>(delta.layer(layer).borrow(), &mut ranges); }
 
             let mut notes_rc = delta.pop_layer().unwrap();
-            let notes = &mut Rc::make_mut(&mut notes_rc).list.values.values;
+            let notes = &mut Rc::make_mut(&mut notes_rc).list.make_typed().values.values;
             for (count, range) in counts.iter().zip(ranges.iter()) {
                 let order = (count+1).ilog2() as u8;
                 for index in range.0 .. range.1 {
@@ -137,7 +137,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
             // side, preserving the "column 0 is the partition key" invariant
             // without any further coordination. Single-worker prefix-0 falls
             // through to `join_many` below, which handles the local Cartesian.
-            use columnar::{Borrow, Container, Len};
+            use columnar::{Container, Len};
             use crate::facts::trie::Layer;
             comms.broadcast(&mut salad.facts);
             if let Some(salad_full) = salad.facts.flatten() {

--- a/src/rules/atoms/logic.rs
+++ b/src/rules/atoms/logic.rs
@@ -132,7 +132,7 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
             //      Each present element of `self.bound` presents as a pair of borrowed container and list of counts for each element.
             //      All present pairs should have the same sum of counts, indicating the total number of argument tuples.
             let max = self.bound.iter().flatten().flat_map(|term| salad.terms.iter().position(|t| t == term)).max();
-            let cnt = max.map(|col| delta.layer(col).list.values.len()).unwrap_or(1);
+            let cnt = max.map(|col| delta.layer(col).list.borrow().values.len()).unwrap_or(1);
 
             //  Long-lived containers for literal values.
             //  In an FDB world, we would put these at the root, independent of any input data, rather than to the side.
@@ -145,10 +145,10 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
                 match arg {
                     Ok(term) => {
                         salad.terms.iter().position(|t| t == term).map(|col| {
-                            let mut bounds = (0 .. delta.layer(col).list.values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
+                            let mut bounds = (0 .. delta.layer(col).list.borrow().values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
                             for i in col+1 .. max.unwrap()+1 { advance_bounds::<Terms>(delta.layer(i).borrow(), &mut bounds)};
                             let counts = bounds.into_iter().map(|(l, u)| u-l).collect::<Vec<_>>();
-                            (delta.layer(col).list.values.borrow(), counts)
+                            (delta.layer(col).list.borrow().values, counts)
                         })
                     },
                     Err(_) => { Some((lits[index].borrow(), vec![cnt] )) },
@@ -162,7 +162,7 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
             //  3.  Project the output forward to the count column, potentially update count and index.
             let orders = match max {
                 Some(col) => {
-                    let mut bounds = (0 .. delta.layer(col).list.values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
+                    let mut bounds = (0 .. delta.layer(col).list.borrow().values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
                     for i in col+1 .. delta.arity() { advance_bounds::<Terms>(delta.layer(i).borrow(), &mut bounds)};
                     bounds.into_iter().map(|(l,u)| u-l).collect::<Vec<_>>()
                 },
@@ -170,7 +170,7 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
             };
 
             let mut notes_rc = delta.pop_layer().unwrap();
-            let notes = &mut Rc::make_mut(&mut notes_rc).list.values.values;
+            let notes = &mut Rc::make_mut(&mut notes_rc).list.make_typed().values.values;
             for (index, order) in orders.into_iter().enumerate().flat_map(|(i,c)| std::iter::repeat(output[i]).take(c)).enumerate() {
                 if let Some(order) = order {
                     let order: u8 = (order+1).ilog2() as u8;
@@ -194,7 +194,7 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
             //      Each present element of `self.bound` presents as a pair of borrowed container and list of counts for each element.
             //      All present pairs should have the same sum of counts, indicating the total number of argument tuples.
             let max = self.bound.iter().flatten().flat_map(|term| salad.terms.iter().position(|t| t == term)).max();
-            let cnt = max.map(|col| delta.layer(col).list.values.len()).unwrap_or(1);
+            let cnt = max.map(|col| delta.layer(col).list.borrow().values.len()).unwrap_or(1);
 
             //  Long-lived containers for literal values.
             //  In an FDB world, we would put these at the root, independent of any input data, rather than to the side.
@@ -207,10 +207,10 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
                 match arg {
                     Ok(term) => {
                         salad.terms.iter().position(|t| t == term).map(|col| {
-                            let mut bounds = (0 .. delta.layer(col).list.values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
+                            let mut bounds = (0 .. delta.layer(col).list.borrow().values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
                             for i in col+1 .. max.unwrap()+1 { advance_bounds::<Terms>(delta.layer(i).borrow(), &mut bounds)};
                             let counts = bounds.into_iter().map(|(l, u)| u-l).collect::<Vec<_>>();
-                            (delta.layer(col).list.values.borrow(), counts)
+                            (delta.layer(col).list.borrow().values, counts)
                         })
                     },
                     Err(_) => { Some((lits[index].borrow(), vec![cnt] )) },
@@ -239,7 +239,7 @@ impl<T: Ord + Clone> exec::ExecAtom<T> for LogicRel<T> {
                             colnew.push(column.borrow().get(idx));
                         }
                     }
-                    delta.push_layer(Rc::new(Layer { list: colnew }));
+                    delta.push_layer(Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(colnew) }));
                     salad.facts.push(delta);
                 }
                 salad.terms.push(added.iter().next().unwrap().clone());

--- a/src/rules/exec.rs
+++ b/src/rules/exec.rs
@@ -169,7 +169,7 @@ pub fn wco_join<T: Ord + Clone + std::fmt::Debug>(
                 // each worker only has its shard of `prefix`, so the local
                 // contribution to the global Cartesian is exactly the slice
                 // whose key falls on this worker.
-                use columnar::{Borrow, Container, Len};
+                use columnar::{Container, Len};
                 use crate::facts::trie::Layer;
                 comms.broadcast(&mut salad.facts);
                 let mut out = FactLSM::default();
@@ -234,13 +234,13 @@ fn wco_join_inner<T: Ord + Clone + std::fmt::Debug>(
     // Flatten to gain access to facts, to append counts.
     if let Some(mut facts) = salad.facts.flatten() {
         let values = vec![255u8; 4 * facts.len()];
-        facts.push_layer(Rc::new(Layer { list: Lists {
+        facts.push_layer(Rc::new(Layer { list: columnar::bytes::stash::Stash::Typed(Lists {
             bounds: Strides::new(1, facts.len() as u64),
             values: Lists {
                 bounds: Strides::new(4, facts.len() as u64),
                 values,
             },
-        }}));
+        }) }));
         salad.facts.push(facts);
     }
     salad.terms.push(potato);
@@ -250,11 +250,15 @@ fn wco_join_inner<T: Ord + Clone + std::fmt::Debug>(
 
     //  2.  Partition `salad.facts` by atom index, and join to get proposals.
     salad.terms.pop();
-    let notes = if let Some(mut facts) = salad.facts.flatten() {
-        let notes = Rc::unwrap_or_clone(facts.pop_layer().unwrap()).list.values.values;
+    let notes_layer: Option<Rc<crate::facts::trie::Layer<Terms>>> = if let Some(mut facts) = salad.facts.flatten() {
+        let layer = facts.pop_layer().unwrap();
         salad.extend([facts]);
-        notes
-    } else { Default::default() };
+        Some(layer)
+    } else { None };
+    let notes: &[u8] = match notes_layer.as_deref() {
+        Some(layer) => layer.list.borrow().values.values,
+        None => &[],
+    };
     let mut bools = std::collections::VecDeque::with_capacity(notes.len()/4);
 
     let mut shards = Vec::with_capacity(atoms.len());

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn eval(ptr: *mut u8, len: usize) {
 /// Command dispatch: a focused subset of the CLI's `handle_command`, covering
 /// what the talk demos need. Rules and facts go through the parser; directives
 /// are matched by leading token. `.plan`/`.prof` read in-memory state and so
-/// port cleanly; `.heap`/`.load`/`.flow` stay CLI-only (mimalloc / real files).
+/// port cleanly; `.heap`/`.load`/`.read`/`.flow` stay CLI-only (mimalloc / real files).
 fn dispatch(state: &mut types::State, text: &str) {
     if let Some(parsed) = parse::datalog(text) {
         state.extend(parsed);


### PR DESCRIPTION
Persist a relation's Identity form (its FactSet's stable LSM layers plus the recent slot if present) to a directory tree and restore it on a later run via mmap. On the directive level:
```
  .save <name> <dir>     atomic stage-then-rename into
                         <dir>/<name>/identity/lsm_NNN/layer_NNN.bin
  .load <name> <dir>     mmap each layer file into the relation as a
                         Stash<Lists<Terms>, Bytes>::Bytes; nothing
                         decoded or copied, pages fault on access
```
Renames the previous text-ingest directive `.load <name> <regex> <file>` to `.read <name> <regex> <file>` so the two paths don't collide on leading token and differ only in arity. `.load` is now binary-only; `.read` is text-only.

Wire format per layer file: one columnar `indexed::write` blob holding the whole Vecs<Vecs<Vec<u8>, Strides>, Strides> of that trie column. On load, Stash::try_from_bytes validates the framing in O(1). Save can hand the file fd a Typed layer (goes through indexed::write on a non-owning borrow) or a Bytes-backed layer (dumped straight from the source mmap to the target fd, no structural copy).

In-memory representation:
```rust
  pub type Terms = Lists<Vec<u8>>;
  pub struct Layer<C: ContainerBytes> {
      pub list: Stash<Lists<C>, timely_bytes::arc::Bytes>,
  }
```
Layer can carry an owned Lists or an mmap-backed one transparently; read paths through .list.borrow() are oblivious. Write paths go through .list.make_typed(), which materializes once on first mutation of a Bytes-backed layer (no-op for Typed). The mutation sites in atoms/data.rs and atoms/logic.rs descend
.list.make_typed().values.values to overwrite per-fact count bytes.

`FactMessage` on the comms wire carries Vec<Stash<Lists<Terms>, Bytes>> rather than Vec<Lists<Terms>>, so mmap-backed layers cross worker boundaries without being materialized into owned Lists at either send or receive.

`.load`'s relation entry is populated by pushing the loaded forests straight into `entry.stable`, bypassing the to_add -> recent -> flatten pipeline (which would otherwise merge all 8 LSM layers into one, walking the entire 134 MB of saved bytes — exactly the work mmap is meant to avoid). Loaded forests are already deduped and sorted by construction (they were stable LSM layers when saved), so the pipeline's flatten precondition is already satisfied.

Atomic .save: stage to <dir>/<name>/.identity.staging.<pid>.<nanos>/, rename old identity/ aside to .identity.trash.*, rename staging into place, remove the trash. A crash mid-write leaves the existing identity/ untouched; a smaller new save doesn't leave stale lsm_N/ from the prior contents. There's a brief window between the two renames where identity/ doesn't exist for a concurrent reader — true atomic swap would need renameat2(RENAME_EXCHANGE) on Linux or renamex_np (RENAME_SWAP) on macOS, which we skip for portability.

mmap of the layer file uses MmapOptions::map_copy (MAP_PRIVATE CoW): satisfies timely_bytes::BytesMut::from's DerefMut requirement without needing write access to the underlying file, and the COW pages would absorb any local writes — but make_typed always replaces the Stash variant before mutation so no page is ever modified.

Removed two derives that gummed up the type bounds:
  Forest<C> no longer derives Debug — it would commit any embedded
    column type to Debug, and `{:?}`-formatting a 35M-fact relation is
    never useful.
  Layer<C> no longer derives Debug for the same reason.
The Vec<Rc<Layer<C>>>::try_into() -> Forest<C> sites that previously relied on Result::expect's `Err: Debug` constraint switch to .ok().expect("…") (Option::expect has no Debug bound).

Cargo: columnar pinned to git for the Container-for-Stash impl in frankmcsherry/columnar#110. Adds memmap2 and bytemuck as direct deps.

Twitter Reach demo (35M facts, 134 MB on disk, cold restart with page cache purged, single worker, default mem budget):
```
  load + compute reach + save:    136 s    (one-time)
  cold .load Reach:               560 us
  RSS after .load:                3.14 MiB
  single point query (range
    on bound side first):         50–100 us
  on-disk file count:             8 files
```
The point-query latency floor here is the engine, not storage; a naively-ordered rule (`Reach(x), :range(N, x, N+1)`) seeds from the 35M-fact side and validates each fact against the range, costing ~640 ms regardless of the lookup target. Writing the rule with :range first (`:range(N, x, N+1), Reach(x)`) seeds from the 1-fact side and drops to the µs range. Real planner work; not in scope here.

Caveats:
- The bypass of state.extend_facts in .load also skips comms.exchange/broadcast, which is correct for single-worker but breaks distributed loads (every worker would keep the forests it loaded). Sharded on-disk format or per-worker dispatch would close that.
- Loaded data is trusted to be deduplicated; a second .load of the same dataset would produce duplicates in entry.stable.
- mmap_layer uses unsafe (memmap2's API requirement). The COW mapping protects against our own writes; the residual risk is another process truncating the file out from under us, which would SIGBUS. In normal operation we are the only writer.