### PR TITLE
Route join/count prefix intersection through the width-specializing dispatcher

### DIFF
--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -475,7 +475,7 @@ pub mod terms {
             let mut this_aligned = Vec::new();
             for other in 0 .. thats.len() {
                 let layer1 = &thats[other][layer];
-                let results = crate::facts::trie::layers::intersection::<Terms>(*layer0, *layer1, &aligned[other].0, &aligned[other].1);
+                let results = crate::facts::trie::layers::terms::intersection(*layer0, *layer1, &aligned[other].0, &aligned[other].1);
                 this_aligned.extend_from_slice(&results.0);
                 aligned[other] = (Rc::new(results.0), Rc::new(results.1));
             }

--- a/src/rules/atoms/data.rs
+++ b/src/rules/atoms/data.rs
@@ -29,7 +29,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
 
         use columnar::Len;
         use crate::facts::trie::layers::advance_bounds;
-        use crate::facts::trie::layers::intersection;
+        use crate::facts::trie::layers::terms::intersection;
 
         let (other_facts, other_terms, _other_recent) = self;
 
@@ -58,7 +58,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
                 for other_part in other_facts.iter() {
                     let mut delta_idxs = vec![0];
                     let mut other_idxs = vec![0];
-                    for layer in 0 .. prefix { (delta_idxs, other_idxs) = intersection::<Terms>(delta.layer(layer).borrow(), other_part.layer(layer).borrow(), &delta_idxs, &other_idxs); }
+                    for layer in 0 .. prefix { (delta_idxs, other_idxs) = intersection(delta.layer(layer).borrow(), other_part.layer(layer).borrow(), &delta_idxs, &other_idxs); }
                     // The count derives from projecting `other_idxs` forward through `terms`.
                     let mut ranges = other_idxs.iter().map(|i| (*i,*i+1)).collect::<Vec<_>>();
                     for layer in prefix .. (prefix + terms.len()) { advance_bounds::<Terms>(other_part.layer(layer).borrow(), &mut ranges); }


### PR DESCRIPTION
`join_cols` and the data atom's `count` called the generic `layers::intersection::<Terms>` directly, comparing variable-width byte slices element by element.
The `terms::intersection` dispatcher (already used by `retain_inner`) upgrades uniform-width columns to fixed-width `[u8; N]` and compares those instead.
This routes both call sites through the dispatcher; no behavior change, all `.test` checks pass (remy, batik, polonius, tc-10k, sg-10k).

Benchmarked on mini-03 (single node, 1 worker), 6 interleaved reps per config, before = d197ede, after = this branch.
Every workload improved; per-rep distributions do not overlap on the big movers.

| workload | before | after | delta |
|---|---|---|---|
| csda-alt / postgresql | 4.606s | 4.138s | -10.2% |
| csda-alt / linux | 7.420s | 6.911s | -6.9% |
| csda-alt / httpd | 1.191s | 1.111s | -6.8% |
| cspa-alt / linux | 3.818s | 3.584s | -6.1% |
| cspa-alt / postgresql | 7.936s | 7.756s | -2.3% |
| z3-alt / DDISASM | 54.98s | 53.98s | -1.8% |
| batik-alt / doop | 25.18s | 24.76s | -1.7% |
| galen | 11.47s | 11.34s | -1.1% |
| cspa-alt / httpd | 6.849s | 6.782s | -1.0% |
| cvc5-alt / DDISASM | 15.67s | 15.63s | -0.2% |

The dense, merge-heavy prefix intersections (csda, cspa) benefit most; gallop-dominated closure workloads see smaller but consistent gains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)