### PR TITLE
Build release with a single codegen unit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,14 @@ simd-csv = "0.10.3"
 timely_bytes = { version = "0.30" }
 timely_communication = { version = "0.30" }
 
+[profile.release]
+# One codegen unit, so that inlining is deterministic across builds. The default (16)
+# partitions the crate by size estimate, and a one-line source change can reshuffle
+# which functions share a unit, silently swinging hot-path inlining and benchmarks by
+# 10-25%. A single unit also measured faster than the default (fewer cycles, despite
+# more instructions retired), and compile time is not a constraint here.
+codegen-units = 1
+
 [features]
 # mimalloc is the CLI allocator and backs the `.heap` directive's stats. It is C, so
 # cross-compiling it to wasm needs a wasi-sdk (clang + sysroot) we don't carry — not


### PR DESCRIPTION
The default 16 codegen units partition the crate by size estimate, and a one-line source change can reshuffle which functions share a unit, silently swinging hot-path inlining.
We measured a single-line planner edit costing +24% instructions retired and +8.5% cycles on remy (N=1e6), with the effect appearing and vanishing as unrelated edits (eprintln instrumentation, debuginfo) reshuffled the partition.
Sampling 8 builds of identical source via `-C metadata` seeds confirmed the partition is deterministic in the source: rolls agree within 0.35%, so the swing is a discontinuity at source perturbations, not per-build randomness.
This makes A/B benchmarking across source changes unreliable at the default setting.

A single codegen unit makes inlining deterministic and also measured faster outright on remy:

| build | instructions (med) | cycles (med) |
|---|---|---|
| default, 8 metadata rolls | 2.949-2.959B | 776-799M |
| codegen-units = 1 | 3.024B | 747M |

Fewer cycles despite more instructions retired; wall clock matches.
Full builds go from ~10s to ~16-19s, which is not a constraint here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)