### PR TITLE
Elide the stage-0 semijoin that bridges into stage 1

### DIFF
--- a/src/rules/plan.rs
+++ b/src/rules/plan.rs
@@ -350,6 +350,20 @@ pub fn plan_body<A: Ord+Copy, T: Ord+Clone+std::fmt::Debug>(
         }
     }
 
+    if plan.len() >= 2 {
+        // Elide an atom that ends phase 0 and starts phase 1: the LAST stage-0
+        // semijoin in execution order that is also the FIRST stage-1 atom in count
+        // order. Adjacency makes the elision free on every axis: no sibling stage-0
+        // semijoin sees unfiltered rows (they all ran earlier), no other count
+        // touches dead rows (its count runs first, and zero counts prune), and its
+        // count's align_to is the same permute the semijoin would have performed.
+        let s0_last = plan[0].0.iter().next_back().cloned();
+        let s1_first = plan[1].0.iter().next().cloned();
+        if let (Some(a), Some(b)) = (s0_last, s1_first) {
+            if a == b { plan[0].0.remove(&a); }
+        }
+    }
+
     // Set each stage's projection target by demand from later stages plus `need`.
     for index in 1 .. plan.len() {
         let (this, rest) = plan.split_at_mut(index);


### PR DESCRIPTION
A stage-0 semijoin whose atom reappears in stage 1 is logically redundant: the stage-1 count race re-performs its prefix intersect, and `remove_zeros` prunes zero-count rows with the same retain machinery.
But eliding is only free when nothing runs between the filter and the re-check.
Phase-level accounting (time and rows per semijoin/permute/count/join phase) identified two exposure channels that make eager elision a loss: stage-0 sibling semijoins running after the elided atom see unfiltered rows, and stage-1 counts/aligns running before the atom's own count process rows it would have killed.

Gates measured along the way (mini-03, 1x1, 6 interleaved reps, codegen-units=1, vs main):

| workload | unconditional | arity-1 gate | first-in-stage-1 gate | bridge (this PR) |
|---|---|---|---|---|
| galen | -7.1% | 0.0% | +6.8% | **-0.9%** |
| batik | +6.8% | +0.1% | +1.8% | **-0.5%** |
| csda httpd | -7.1% | -6.9% | -6.8% | **-6.8%** |
| csda linux | -8.4% | -7.7% | -7.7% | **-8.0%** |
| csda postgresql | -12.2% | -12.6% | -11.7% | **-12.0%** |

The bridge condition elides exactly the atom that is LAST in stage-0 execution order and FIRST in stage-1 count order.
Both exposure channels are closed by construction, and the atom's count-leading `align_to` is the same permute its semijoin performed, so every cost term cancels; the elision nets the removal of one redundant intersect.
Non-losing on every measured workload, with csda's wins retained in full.

galen's larger unconditional win (-7.1%) comes from non-adjacent, alignment-forcing sites; recovering it safely is a planner-ordering question (arranging atoms so more sites satisfy adjacency), left for future work.
Full `.test` battery passes (remy, batik, polonius, tc-10k, sg-10k).

🤖 Generated with [Claude Code](https://claude.com/claude-code)