### PR TITLE
`FactColumn` trait

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -39,7 +39,7 @@ impl Comms {
 
     pub fn next_id(&self) -> usize { self.count }
 
-    pub fn conduit(&mut self) -> Conduit {
+    pub fn conduit<F: Exchangeable>(&mut self) -> Conduit<F> {
         let budget = self.mem_budget;
         let comms = self.ether.as_mut().map(|comms| {
             let (sends, recv) = comms.borrow_mut().allocate(self.count);
@@ -170,18 +170,32 @@ pub struct Channel {
     done: bool,
 }
 
+/// Facts that can be exchanged among workers over a `Channel`.
+///
+/// The implementation owns the routing of facts to peers and the message encoding.
+/// Implemented for `Forest<Terms>` only at the moment; other fact containers will
+/// need their own routing and encoding (or a generalized `FactMessage`).
+pub trait Exchangeable: crate::facts::Merge + crate::facts::Length + crate::facts::Arity + Sized {
+    /// Exchanges facts with other participants, drawing from and refilling `facts`.
+    fn exchange(channel: &mut Channel, facts: &mut FactLSM<Self>);
+    /// Extracts all remaining facts, closing the channel.
+    fn complete(mut channel: Channel) -> FactLSM<Self> {
+        channel.close();
+        let mut facts = FactLSM::default();
+        while channel.count > 0 { let mut temp = FactLSM::default(); Self::exchange(&mut channel, &mut temp); facts.extend(temp); }
+        facts
+    }
+}
+
+impl Exchangeable for Forest<Terms> {
+    fn exchange(channel: &mut Channel, facts: &mut FactLSM<Self>) { channel.exchange(facts) }
+}
+
 impl Channel {
     fn close(&mut self) { if !self.done {
         for sender in self.sends.iter_mut() { sender.send(FactMessage { facts: None } ); }
         self.done = true;
     }}
-    /// Extracts all remaining facts
-    fn complete(mut self) -> FactLSM<Forest<Terms>> {
-        self.close();
-        let mut facts = FactLSM::default();
-        while self.count > 0 { let mut temp = FactLSM::default(); self.exchange(&mut temp); facts.extend(temp); }
-        facts
-    }
     /// Exchanges facts with other participants, drawing from and refilling `facts`.
     fn exchange(&mut self, facts: &mut FactLSM<Forest<Terms>>) {
 
@@ -222,28 +236,28 @@ impl Channel {
 ///
 /// Internally, a communication protocol with other peers relies on each eventually sending an empty `FactMessage`.
 /// Once as many of these have been received as there are peers, the exchange is complete.
-pub struct Conduit {
+pub struct Conduit<F = Forest<Terms>> {
     /// Communication infrastructure.
     comms: Option<Channel>,
-    facts: FactLSM<Forest<Terms>>,
+    facts: FactLSM<F>,
     /// Snapshot of the cluster-wide budget at allocation time.
     mem_budget: usize,
 }
 
-impl Conduit {
+impl<F: Exchangeable> Conduit<F> {
     /// The number of peers backing the conduit.
     pub fn peers(&self) -> usize { self.comms.as_ref().map(|c| c.comms.borrow().peers()).unwrap_or(1) }
     /// Per-peer slice of the cluster-wide budget. Mirrors `Comms::thresh`.
     pub fn thresh(&self) -> usize { self.mem_budget / self.peers() }
     /// Supplies facts to the conduit, which are exchanged and then collected.
-    pub fn extend(&mut self, facts: &mut FactLSM<Forest<Terms>>) {
-        if let Some(channel) = self.comms.as_mut() { channel.exchange(facts); }
+    pub fn extend(&mut self, facts: &mut FactLSM<F>) {
+        if let Some(channel) = self.comms.as_mut() { F::exchange(channel, facts); }
         self.facts.extend(std::mem::take(facts));
     }
     pub fn close(&mut self) { if let Some(channel) = self.comms.as_mut() { channel.close(); } }
     /// Finalizes the facts awaiting receipt from all other participants.
-    pub fn finish(mut self) -> FactLSM<Forest<Terms>> {
-        if let Some(channel) = self.comms { self.facts.extend(channel.complete()); }
+    pub fn finish(mut self) -> FactLSM<F> {
+        if let Some(channel) = self.comms { self.facts.extend(F::complete(channel)); }
         self.facts
     }
 }

--- a/src/comms.rs
+++ b/src/comms.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 
 use timely_communication::{allocator::Allocator, Bytesable};
-use crate::facts::{FactLSM, Forest, Lists, Terms};
+use crate::facts::{FactColumn, FactLSM, Forest, Lists, Terms};
 use crate::facts::trie::Layer;
 
 /// Cluster-wide default budget (bytes) for in-flight intermediate tuples.
@@ -39,7 +39,8 @@ impl Comms {
 
     pub fn next_id(&self) -> usize { self.count }
 
-    pub fn conduit<F: Exchangeable>(&mut self) -> Conduit<F> {
+    /// Allocates a conduit for exchanging facts, which requires a serializable column.
+    pub fn conduit<F: Exchangeable>(&mut self) -> Conduit<F> where Lists<F::Column>: columnar::ContainerBytes {
         let budget = self.mem_budget;
         let comms = self.ether.as_mut().map(|comms| {
             let (sends, recv) = comms.borrow_mut().allocate(self.count);
@@ -81,7 +82,7 @@ impl Comms {
     }
 
     /// Broadcasts facts to all workers.
-    pub fn broadcast(&mut self, facts: &mut FactLSM<Forest<Terms>>) {
+    pub fn broadcast<C: FactColumn>(&mut self, facts: &mut FactLSM<Forest<C>>) where Lists<C>: columnar::ContainerBytes {
         if let Some(comms) = self.ether.as_mut() {
             let mut comms = comms.borrow_mut();
             let (senders, mut receiver) = comms.allocate(self.count);
@@ -145,10 +146,10 @@ impl Comms {
     }
 
     /// Exchanges facts among all workers.
-    pub fn exchange(&mut self, facts: &mut FactLSM<Forest<Terms>>) {
+    pub fn exchange<F: Exchangeable>(&mut self, facts: &mut FactLSM<F>) where Lists<F::Column>: columnar::ContainerBytes {
         // Single-worker: nothing to shuffle, facts already local.
         if self.peers() == 1 { return; }
-        let mut conduit = self.conduit();
+        let mut conduit = self.conduit::<F>();
         conduit.extend(facts);
         *facts = conduit.finish();
     }
@@ -162,10 +163,10 @@ impl From<Allocator> for Comms {
 
 use timely_communication::{Push, Pull};
 
-pub struct Channel {
+pub struct Channel<C: FactColumn = Terms> {
     comms: Rc<RefCell<Allocator>>,
-    sends: Vec<Box<dyn Push<FactMessage>>>,
-    recv: Box<dyn Pull<FactMessage>>,
+    sends: Vec<Box<dyn Push<FactMessage<C>>>>,
+    recv: Box<dyn Pull<FactMessage<C>>>,
     count: usize,
     done: bool,
 }
@@ -173,13 +174,15 @@ pub struct Channel {
 /// Facts that can be exchanged among workers over a `Channel`.
 ///
 /// The implementation owns the routing of facts to peers and the message encoding.
-/// Implemented for `Forest<Terms>` only at the moment; other fact containers will
-/// need their own routing and encoding (or a generalized `FactMessage`).
+/// The blanket implementation for `Forest<C>` routes by `FactColumn::route` of the
+/// first column, and encodes messages as one columnar stash per layer.
 pub trait Exchangeable: crate::facts::Merge + crate::facts::Length + crate::facts::Arity + Sized {
+    /// The column container exchanged in messages.
+    type Column: FactColumn;
     /// Exchanges facts with other participants, drawing from and refilling `facts`.
-    fn exchange(channel: &mut Channel, facts: &mut FactLSM<Self>);
+    fn exchange(channel: &mut Channel<Self::Column>, facts: &mut FactLSM<Self>);
     /// Extracts all remaining facts, closing the channel.
-    fn complete(mut channel: Channel) -> FactLSM<Self> {
+    fn complete(mut channel: Channel<Self::Column>) -> FactLSM<Self> {
         channel.close();
         let mut facts = FactLSM::default();
         while channel.count > 0 { let mut temp = FactLSM::default(); Self::exchange(&mut channel, &mut temp); facts.extend(temp); }
@@ -187,17 +190,18 @@ pub trait Exchangeable: crate::facts::Merge + crate::facts::Length + crate::fact
     }
 }
 
-impl Exchangeable for Forest<Terms> {
-    fn exchange(channel: &mut Channel, facts: &mut FactLSM<Self>) { channel.exchange(facts) }
+impl<C: FactColumn> Exchangeable for Forest<C> {
+    type Column = C;
+    fn exchange(channel: &mut Channel<C>, facts: &mut FactLSM<Self>) { channel.exchange(facts) }
 }
 
-impl Channel {
+impl<C: FactColumn> Channel<C> {
     fn close(&mut self) { if !self.done {
         for sender in self.sends.iter_mut() { sender.send(FactMessage { facts: None } ); }
         self.done = true;
     }}
     /// Exchanges facts with other participants, drawing from and refilling `facts`.
-    fn exchange(&mut self, facts: &mut FactLSM<Forest<Terms>>) {
+    fn exchange(&mut self, facts: &mut FactLSM<Forest<C>>) {
 
         if self.done && !facts.is_empty() { panic!("Exchanging on a sealed channel"); }
 
@@ -207,7 +211,7 @@ impl Channel {
         if let Some(facts) = facts.flatten() {
             let mut bools: std::collections::VecDeque<bool> = Default::default();
             for (index, sender) in self.sends.iter_mut().enumerate() {
-                bools.extend((0 .. facts.layer(0).list.values.len()).map(|i| (*facts.layer(0).list.values.borrow().get(i).as_slice().last().unwrap() as usize) % comms.peers() == index));
+                bools.extend((0 .. facts.layer(0).list.values.len()).map(|i| (C::route(facts.layer(0).list.values.borrow().get(i)) as usize) % comms.peers() == index));
                 if let Some(facts) = facts.clone().retain_core(1, bools.clone()).flatten() {
                     let layers = (0 .. facts.arity()).map(|i| facts.layer(i).clone()).collect::<Vec<_>>();
                     drop(facts);
@@ -236,9 +240,9 @@ impl Channel {
 ///
 /// Internally, a communication protocol with other peers relies on each eventually sending an empty `FactMessage`.
 /// Once as many of these have been received as there are peers, the exchange is complete.
-pub struct Conduit<F = Forest<Terms>> {
+pub struct Conduit<F: Exchangeable = Forest<Terms>> {
     /// Communication infrastructure.
-    comms: Option<Channel>,
+    comms: Option<Channel<F::Column>>,
     facts: FactLSM<F>,
     /// Snapshot of the cluster-wide budget at allocation time.
     mem_budget: usize,
@@ -266,21 +270,21 @@ impl<F: Exchangeable> Conduit<F> {
 ///
 /// The encoding is first the number of columns plus one, with zero indicating `None`.
 /// The columns are then appended.
-struct FactMessage { facts: Option<Vec<Lists<Terms>>> }
+pub struct FactMessage<C: FactColumn = Terms> { facts: Option<Vec<Lists<C>>> }
 
-use columnar::{Borrow, Container, Index, Len, bytes::{indexed, stash::Stash}};
+use columnar::{Borrow, Container, ContainerBytes, Index, Len, bytes::{indexed, stash::Stash}};
 
-impl Bytesable for FactMessage {
+impl<C: FactColumn> Bytesable for FactMessage<C> where Lists<C>: ContainerBytes {
     fn from_bytes(mut bytes: timely_bytes::arc::Bytes) -> Self {
         let count: u64 = u64::from_be_bytes(bytes[..8].try_into().unwrap());
         bytes.extract_to(8);
         if count > 0 {
             let mut columns = Vec::with_capacity(count as usize - 1);
             for _ in 1 .. count {
-                let stash: Stash<Lists<Terms>, timely_bytes::arc::Bytes> = Stash::try_from_bytes(bytes.clone()).unwrap();
+                let stash: Stash<Lists<C>, timely_bytes::arc::Bytes> = Stash::try_from_bytes(bytes.clone()).unwrap();
                 let length = stash.length_in_bytes();
                 let _ = bytes.extract_to(length);
-                let mut column: Lists<Terms> = Default::default();
+                let mut column: Lists<C> = Default::default();
                 column.extend_from_self(stash.borrow(), 0 .. stash.len());
                 columns.push(column);
             }

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -135,6 +135,7 @@ impl Relations {
 
 // pub use list::FactList as FactCollection;
 pub use trie::Forest;
+pub use trie::layers::FactColumn;
 pub type FactCollection = Forest<Terms>;
 
 /// A constant integer to which the facts could be upgraded.

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -200,7 +200,7 @@ pub trait FactContainer : Length + Merge + Arity + Sized + Clone {
     /// Joins `self` and `others` on the first `arity` columns, putting projected results in `builders`.
     ///
     /// The default implementation processes `others` in order, but more thoughtful implementations exist.
-    fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projection: &[usize], conduit: crate::comms::Conduit) -> FactLSM<Self>;
+    fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projection: &[usize], conduit: crate::comms::Conduit<Self>) -> FactLSM<Self>;
 }
 
 /// An evolving set of facts.

--- a/src/facts/mod.rs
+++ b/src/facts/mod.rs
@@ -188,7 +188,7 @@ pub trait Arity {
 }
 
 /// A type that can contain and work with facts.
-pub trait FactContainer : Length + Merge + Arity + Sized + Clone {
+pub trait FactContainer : Length + Merge + Arity + Sized + Clone + crate::comms::Exchangeable {
 
     /// Applies an action to the facts, building the corresponding output.
     fn act_on(&self, action: &Action<Vec<u8>>, thresh: usize) -> FactLSM<Self>;

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -97,7 +97,7 @@ pub mod terms {
     use std::rc::Rc;
     use columnar::{Borrow, Container, Index, Len};
     use crate::facts::{FactContainer, FactLSM, Lists, Terms};
-    use crate::facts::trie::layers::Report;
+    use crate::facts::trie::layers::{FactColumn, Report};
     use crate::types::Action;
 
     use super::{Forest, Layer};
@@ -139,7 +139,7 @@ pub mod terms {
                     values: column.borrow(),
                 };
                 // TODO: Figure out how to avoid `indexs` being literally just `0 .. len`.
-                Rc::new(Layer { list: crate::facts::trie::layers::sort_terms(lists, &mut groups[..], &indexs[..], index == columns_len-1) })
+                Rc::new(Layer { list: Terms::sort(lists, &mut groups[..], &indexs[..], index == columns_len-1) })
             }).collect();
             Some(layers.try_into().expect("empty columns tested earlier"))
         }
@@ -387,12 +387,12 @@ pub mod terms {
             groups_list_layer = col+1;
 
             let last = projection_idx == projection.len() - 1;
-            result.push(Rc::new(Layer { list: crate::facts::trie::layers::sort_terms(layers[col], &mut groups, &indexs, last) }));
+            result.push(Rc::new(Layer { list: Terms::sort(layers[col], &mut groups, &indexs, last) }));
 
             projection_idx += 1;
 
-            // TODO:    Consider fusing this work into the preceding `sort_terms`, as these values will be 1:1 with those entries.
-            //          This would require a more advanced `sort_terms` implementation, one capable of accepting a list of layers.
+            // TODO:    Consider fusing this work into the preceding `sort`, as these values will be 1:1 with those entries.
+            //          This would require a more advanced `sort` implementation, one capable of accepting a list of layers.
             //          The advantage would be fewer (but larger) total rounds of sorting, nearly removing the cost of 1:1 columns.
 
             // For as long as column indexes do not advance, we project values forward 1:1 to meet `groups`.
@@ -413,7 +413,7 @@ pub mod terms {
                 indexs.extend(idents.iter().copied().flat_map(|(l,u)| l..u).zip(bounds.iter().copied().map(|(l,u)| u-l)).flat_map(|(i,c)| std::iter::repeat(i).take(c)));
 
                 let last = projection_idx == projection.len() - 1;
-                result.push(Rc::new(Layer { list: crate::facts::trie::layers::sort_terms(layers[col], &mut groups, &indexs, last) }));
+                result.push(Rc::new(Layer { list: Terms::sort(layers[col], &mut groups, &indexs, last) }));
 
                 projection_idx += 1;
             }
@@ -475,7 +475,7 @@ pub mod terms {
             let mut this_aligned = Vec::new();
             for other in 0 .. thats.len() {
                 let layer1 = &thats[other][layer];
-                let results = crate::facts::trie::layers::terms::intersection(*layer0, *layer1, &aligned[other].0, &aligned[other].1);
+                let results = Terms::intersect(*layer0, *layer1, &aligned[other].0, &aligned[other].1);
                 this_aligned.extend_from_slice(&results.0);
                 aligned[other] = (Rc::new(results.0), Rc::new(results.1));
             }
@@ -565,8 +565,6 @@ pub mod terms {
             // Layers correspond to the columns of `projection`, which we produce in turn.
             let layers = projection.iter().copied().enumerate().map(|(idx, column)| {
 
-                use crate::facts::trie::layers::sort_terms;
-
                 let last = idx+1 == projection.len();
 
                 let list = if column < arity {
@@ -595,7 +593,7 @@ pub mod terms {
                     // Flatten the (index, count) into repetitions.
                     let mut flat = Vec::with_capacity(groups.len());
                     flat.extend(aligneds[column].iter().zip(counts).flat_map(|(i,c)| std::iter::repeat(*i).take(c)));
-                    sort_terms(this[column], &mut groups, &flat, last)
+                    Terms::sort(this[column], &mut groups, &flat, last)
                 }
                 else if column < this.len() {
                     // We expect this to be the next column in `this_values`.
@@ -605,7 +603,7 @@ pub mod terms {
                     // Expand `this_i`, and corresponding repetitions in `groups` and `that_j`.
                     let mut others = if that_cursor < that_values.len() { vec![&mut groups, Rc::make_mut(&mut that_j)] } else { vec![&mut groups] };
                     expand(Rc::make_mut(&mut this_i), values, &mut others);
-                    sort_terms(values, &mut groups, &this_i, last)
+                    Terms::sort(values, &mut groups, &this_i, last)
                 }
                 else if column < this.len() + arity { unimplemented!("reference equated column of first join argument") }
                 else {
@@ -616,7 +614,7 @@ pub mod terms {
                     // Expand `that_j`, and corresponding repetitions in `groups` and `this_i`.
                     let mut others = if this_cursor < this_values.len() { vec![&mut groups, Rc::make_mut(&mut this_i)] } else { vec![&mut groups] };
                     expand(Rc::make_mut(&mut that_j), values, &mut others);
-                    sort_terms(values, &mut groups, &that_j, last)
+                    Terms::sort(values, &mut groups, &that_j, last)
                 };
                 Rc::new(Layer { list })
             }).collect::<Vec<_>>();
@@ -783,7 +781,7 @@ pub mod terms {
             for other in others.iter() {
                 let mut reports = (vec![0], vec![0]);
                 for (layer0, layer1) in self.layers.iter().zip(other.iter()) {
-                    reports = crate::facts::trie::layers::terms::intersection(layer0.borrow(), *layer1, &reports.0, &reports.1);
+                    reports = Terms::intersect(layer0.borrow(), *layer1, &reports.0, &reports.1);
                 }
                 // Mark shared paths appropriately.
                 for index in reports.0.iter().copied() { include[index] = semi; }
@@ -836,9 +834,11 @@ pub mod terms {
 
 /// Layer-at-a-time functionality.
 ///
-/// These are meant to be the high-performance kernels used by forests of more general layers.
-/// Implementations for `Layer<Terms>` are "abstract" and not performance optimized, whereas
-/// the implementations for generic container types are "specialized" and potentially efficient.
+/// The `FactColumn` trait names the kernels a container must supply to back a `Layer`,
+/// and the free functions here are generic implementations of those kernels for any
+/// container with `Ord` references, to which an implementor can defer one line at a time.
+/// The `Terms` implementation instead dispatches to width-specialized variants when the
+/// data allow.
 pub mod layers {
 
     use std::collections::VecDeque;
@@ -863,71 +863,91 @@ pub mod layers {
         Both(usize, usize),
     }
 
-    /// Layer-at-a-time methods for general `Layer<Term>` types, specialized as appropriate.
-    ///
-    /// These methods are specialized to various array sizes, mostly for demonstration purposes.
-    /// These sizes are not specifically important, but we do want to support this sort of thing.
-    impl Layer<Terms> {
+    /// Layer-at-a-time methods for any `Layer<C>` whose container implements `FactColumn`.
+    impl<C: FactColumn> Layer<C> {
         /// Unions two layers, aligned through `reports`, which is refilled if `next` is set.
-        pub fn union(&self, other: &Self, reports: &mut VecDeque<Report>, next: bool) -> Self { Self { list: terms::union(self.borrow(), other.borrow(), reports, next) } }
+        pub fn union(&self, other: &Self, reports: &mut VecDeque<Report>, next: bool) -> Self { Self { list: C::union(self.borrow(), other.borrow(), reports, next) } }
 
         /// Intersects two layers, aligned through `aligns`.
-        pub fn intersection(&self, other: &Self, both0: &[usize], both1: &[usize]) -> (Vec<usize>, Vec<usize>) { terms::intersection(self.borrow(), other.borrow(), both0, both1) }
+        pub fn intersection(&self, other: &Self, both0: &[usize], both1: &[usize]) -> (Vec<usize>, Vec<usize>) { C::intersect(self.borrow(), other.borrow(), both0, both1) }
 
         /// Retains lists indicated by `retain`, which is refilled.
-        pub fn retain_lists(&self, bounds: &mut [(usize, usize)]) -> Self { Self { list: terms::retain_lists(self.borrow(), bounds) } }
+        pub fn retain_lists(&self, bounds: &mut [(usize, usize)]) -> Self { Self { list: C::retain_lists(self.borrow(), bounds) } }
 
         /// Retains items indicated by `retain`, which is refilled.
-        pub fn retain_items(&self, retain: &mut VecDeque<bool>) -> Self { Self { list: terms::retain_items(self.borrow(), retain) } }
+        pub fn retain_items(&self, retain: &mut VecDeque<bool>) -> Self { Self { list: C::retain_items(self.borrow(), retain) } }
     }
 
-    pub mod terms {
-
-        use std::collections::VecDeque;
-        use columnar::Borrow;
-        use crate::facts::{Lists, Terms};
-        use crate::facts::trie::layers::Report;
-        use crate::facts::{upgrade_hint, upgrade, downgrade};
-
+    /// The operations a column container must support to serve as the values of a `Layer`.
+    ///
+    /// Each method is a layer-at-a-time kernel: it works on the values of one layer, and
+    /// communicates with adjacent layers only through type-erased state (`Report`s, index
+    /// bounds, and grouping identifiers). Implementors whose references are `Ord` can defer
+    /// to the generic kernels in this module (`union`, `intersection`, `retain_lists`,
+    /// `retain_items`, `col_sort`), each one line. The `Terms` implementation instead
+    /// inspects the data for fixed widths, and dispatches to kernels specialized to those
+    /// widths.
+    pub trait FactColumn: Container + Clone {
+        /// Sorts the items of `lists` at `indexs` subject to the grouping/ordering of `groups`.
+        ///
+        /// Mints a new item for each distinct `(group, item)` pair and a new list for each
+        /// distinct group, rewriting `groups` with output item indexes unless `last` is set.
+        fn sort(lists: <Lists<Self> as Borrow>::Borrowed<'_>, groups: &mut [usize], indexs: &[usize], last: bool) -> Lists<Self>;
         /// Unions two layers, aligned through `reports`, which is refilled if `next` is set.
-        pub fn union(lists0: <Lists<Terms> as Borrow>::Borrowed<'_>, lists1: <Lists<Terms> as Borrow>::Borrowed<'_>, reports: &mut VecDeque<Report>, next: bool) -> Lists<Terms> {
-            match (upgrade_hint(lists0), upgrade_hint(lists1)) {
-                (Some(1), Some(1)) => { downgrade(super::union(upgrade::<1>(lists0).unwrap(), upgrade::<1>(lists1).unwrap(), reports, next)) }
-                (Some(2), Some(2)) => { downgrade(super::union(upgrade::<2>(lists0).unwrap(), upgrade::<2>(lists1).unwrap(), reports, next)) }
-                (Some(3), Some(3)) => { downgrade(super::union(upgrade::<3>(lists0).unwrap(), upgrade::<3>(lists1).unwrap(), reports, next)) }
-                (Some(4), Some(4)) => { downgrade(super::union(upgrade::<4>(lists0).unwrap(), upgrade::<4>(lists1).unwrap(), reports, next)) }
-                _ => { super::union(lists0, lists1, reports, next) }
-            }
-        }
-        /// Intersects two layers, aligned through `aligns`.
-        pub fn intersection(lists0: <Lists<Terms> as Borrow>::Borrowed<'_>, lists1: <Lists<Terms> as Borrow>::Borrowed<'_>, both0: &[usize], both1: &[usize]) -> (Vec<usize>, Vec<usize>) {
-            // Update `aligns` for the next layer, or output.
-            match (upgrade_hint(lists0), upgrade_hint(lists1)) {
-                (Some(1), Some(1)) => { super::intersection::<Vec<[u8; 1]>>(upgrade::<1>(lists0).unwrap(), upgrade::<1>(lists1).unwrap(), both0, both1) }
-                (Some(2), Some(2)) => { super::intersection::<Vec<[u8; 2]>>(upgrade::<2>(lists0).unwrap(), upgrade::<2>(lists1).unwrap(), both0, both1) }
-                (Some(3), Some(3)) => { super::intersection::<Vec<[u8; 3]>>(upgrade::<3>(lists0).unwrap(), upgrade::<3>(lists1).unwrap(), both0, both1) }
-                (Some(4), Some(4)) => { super::intersection::<Vec<[u8; 4]>>(upgrade::<4>(lists0).unwrap(), upgrade::<4>(lists1).unwrap(), both0, both1) }
-                _ => { super::intersection::<Terms>(lists0, lists1, both0, both1) }
-            }
-        }
-        /// Retains lists indicated by `retain`, which is refilled.
-        pub fn retain_lists(lists: <Lists<Terms> as Borrow>::Borrowed<'_>, bounds: &mut [(usize, usize)]) -> Lists<Terms> {
+        fn union(lists0: <Lists<Self> as Borrow>::Borrowed<'_>, lists1: <Lists<Self> as Borrow>::Borrowed<'_>, reports: &mut VecDeque<Report>, next: bool) -> Lists<Self>;
+        /// Intersects pairs of lists aligned by `both0` and `both1`, producing aligned item indexes.
+        fn intersect(lists0: <Lists<Self> as Borrow>::Borrowed<'_>, lists1: <Lists<Self> as Borrow>::Borrowed<'_>, both0: &[usize], both1: &[usize]) -> (Vec<usize>, Vec<usize>);
+        /// Retains list ranges indicated by `bounds`, which is advanced to bounds on items.
+        fn retain_lists(lists: <Lists<Self> as Borrow>::Borrowed<'_>, bounds: &mut [(usize, usize)]) -> Lists<Self>;
+        /// Retains items indicated by `retain`, which is refilled with per-list bools.
+        fn retain_items(lists: <Lists<Self> as Borrow>::Borrowed<'_>, retain: &mut VecDeque<bool>) -> Lists<Self>;
+    }
+
+    /// Byte strings, specialized at runtime to fixed-width kernels when widths allow.
+    impl FactColumn for Terms {
+        fn sort(lists: <Lists<Terms> as Borrow>::Borrowed<'_>, groups: &mut [usize], indexs: &[usize], last: bool) -> Lists<Terms> {
             match upgrade_hint(lists) {
-                Some(1) => { downgrade(super::retain_lists(upgrade::<1>(lists).unwrap(), bounds)) }
-                Some(2) => { downgrade(super::retain_lists(upgrade::<2>(lists).unwrap(), bounds)) }
-                Some(3) => { downgrade(super::retain_lists(upgrade::<3>(lists).unwrap(), bounds)) }
-                Some(4) => { downgrade(super::retain_lists(upgrade::<4>(lists).unwrap(), bounds)) }
-                _______ => { super::retain_lists(lists, bounds) }
+                Some(1) => { downgrade(col_sort(upgrade::<1>(lists).unwrap().values, groups, indexs, last)) }
+                Some(2) => { downgrade(col_sort(upgrade::<2>(lists).unwrap().values, groups, indexs, last)) }
+                Some(3) => { downgrade(col_sort(upgrade::<3>(lists).unwrap().values, groups, indexs, last)) }
+                Some(4) => { downgrade(u32_sort(upgrade::<4>(lists).unwrap().values, groups, indexs, last)) }
+                _______ => { col_sort(lists.values, groups, indexs, last) }
             }
         }
-        /// Retains items indicated by `retain`, which is refilled.
-        pub fn retain_items(lists: <Lists<Terms> as Borrow>::Borrowed<'_>, retain: &mut VecDeque<bool>) -> Lists<Terms> {
+        fn union(lists0: <Lists<Terms> as Borrow>::Borrowed<'_>, lists1: <Lists<Terms> as Borrow>::Borrowed<'_>, reports: &mut VecDeque<Report>, next: bool) -> Lists<Terms> {
+            match (upgrade_hint(lists0), upgrade_hint(lists1)) {
+                (Some(1), Some(1)) => { downgrade(union(upgrade::<1>(lists0).unwrap(), upgrade::<1>(lists1).unwrap(), reports, next)) }
+                (Some(2), Some(2)) => { downgrade(union(upgrade::<2>(lists0).unwrap(), upgrade::<2>(lists1).unwrap(), reports, next)) }
+                (Some(3), Some(3)) => { downgrade(union(upgrade::<3>(lists0).unwrap(), upgrade::<3>(lists1).unwrap(), reports, next)) }
+                (Some(4), Some(4)) => { downgrade(union(upgrade::<4>(lists0).unwrap(), upgrade::<4>(lists1).unwrap(), reports, next)) }
+                _ => { union(lists0, lists1, reports, next) }
+            }
+        }
+        fn intersect(lists0: <Lists<Terms> as Borrow>::Borrowed<'_>, lists1: <Lists<Terms> as Borrow>::Borrowed<'_>, both0: &[usize], both1: &[usize]) -> (Vec<usize>, Vec<usize>) {
+            match (upgrade_hint(lists0), upgrade_hint(lists1)) {
+                (Some(1), Some(1)) => { intersection::<Vec<[u8; 1]>>(upgrade::<1>(lists0).unwrap(), upgrade::<1>(lists1).unwrap(), both0, both1) }
+                (Some(2), Some(2)) => { intersection::<Vec<[u8; 2]>>(upgrade::<2>(lists0).unwrap(), upgrade::<2>(lists1).unwrap(), both0, both1) }
+                (Some(3), Some(3)) => { intersection::<Vec<[u8; 3]>>(upgrade::<3>(lists0).unwrap(), upgrade::<3>(lists1).unwrap(), both0, both1) }
+                (Some(4), Some(4)) => { intersection::<Vec<[u8; 4]>>(upgrade::<4>(lists0).unwrap(), upgrade::<4>(lists1).unwrap(), both0, both1) }
+                _ => { intersection::<Terms>(lists0, lists1, both0, both1) }
+            }
+        }
+        fn retain_lists(lists: <Lists<Terms> as Borrow>::Borrowed<'_>, bounds: &mut [(usize, usize)]) -> Lists<Terms> {
             match upgrade_hint(lists) {
-                Some(1) => { downgrade(super::retain_items(upgrade::<1>(lists).unwrap(), retain)) }
-                Some(2) => { downgrade(super::retain_items(upgrade::<2>(lists).unwrap(), retain)) }
-                Some(3) => { downgrade(super::retain_items(upgrade::<3>(lists).unwrap(), retain)) }
-                Some(4) => { downgrade(super::retain_items(upgrade::<4>(lists).unwrap(), retain)) }
-                _______ => { super::retain_items(lists, retain) }
+                Some(1) => { downgrade(retain_lists(upgrade::<1>(lists).unwrap(), bounds)) }
+                Some(2) => { downgrade(retain_lists(upgrade::<2>(lists).unwrap(), bounds)) }
+                Some(3) => { downgrade(retain_lists(upgrade::<3>(lists).unwrap(), bounds)) }
+                Some(4) => { downgrade(retain_lists(upgrade::<4>(lists).unwrap(), bounds)) }
+                _______ => { retain_lists(lists, bounds) }
+            }
+        }
+        fn retain_items(lists: <Lists<Terms> as Borrow>::Borrowed<'_>, retain: &mut VecDeque<bool>) -> Lists<Terms> {
+            match upgrade_hint(lists) {
+                Some(1) => { downgrade(retain_items(upgrade::<1>(lists).unwrap(), retain)) }
+                Some(2) => { downgrade(retain_items(upgrade::<2>(lists).unwrap(), retain)) }
+                Some(3) => { downgrade(retain_items(upgrade::<3>(lists).unwrap(), retain)) }
+                Some(4) => { downgrade(retain_items(upgrade::<4>(lists).unwrap(), retain)) }
+                _______ => { retain_items(lists, retain) }
             }
         }
     }
@@ -1131,16 +1151,6 @@ pub mod layers {
         assert_eq!(active.len(), aligned.len());
         let mut aligned = aligned.iter().copied();
         active.retain(|i| lists.values.get(*i) == other.get(aligned.next().unwrap()));
-    }
-
-    pub fn sort_terms(lists: <Lists<Terms> as Borrow>::Borrowed<'_>, groups: &mut [usize], indexs: &[usize], last: bool) -> Lists<Terms> {
-        match upgrade_hint(lists) {
-            Some(1) => { downgrade(col_sort(upgrade::<1>(lists).unwrap().values, groups, indexs, last)) }
-            Some(2) => { downgrade(col_sort(upgrade::<2>(lists).unwrap().values, groups, indexs, last)) }
-            Some(3) => { downgrade(col_sort(upgrade::<3>(lists).unwrap().values, groups, indexs, last)) }
-            Some(4) => { downgrade(u32_sort(upgrade::<4>(lists).unwrap().values, groups, indexs, last)) }
-            _______ => { col_sort(lists.values, groups, indexs, last) }
-        }
     }
 
     /// Sort the items of `lists` subject to the grouping/ordering of `group` of the lists.

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -91,18 +91,18 @@ impl<C: Container> Layer<C> {
     pub fn borrow(&self) -> <Lists<C> as Borrow>::Borrowed<'_> { self.list.borrow() }
 }
 
-/// Implementations for `Forest<Terms>`, for generic byte slices.
-pub mod terms {
+/// Implementations for `Forest<C>`, generic in the column container `C`.
+pub mod forest {
 
     use std::rc::Rc;
     use columnar::{Borrow, Container, Index, Len};
-    use crate::facts::{FactContainer, FactLSM, Lists, Terms};
+    use crate::facts::{FactContainer, FactLSM, Lists};
     use crate::facts::trie::layers::{FactColumn, Report};
     use crate::types::Action;
 
     use super::{Forest, Layer};
 
-    impl crate::facts::Merge for Forest<Terms> {
+    impl<C: FactColumn> crate::facts::Merge for Forest<C> {
         fn merge(self, other: Self) -> Self {
 
             assert_eq!(self.arity(), other.arity());
@@ -118,14 +118,13 @@ pub mod terms {
         }
     }
 
-    impl crate::facts::Length for Forest<Terms> { fn len(&self) -> usize { self.len() } }
+    impl<C: FactColumn> crate::facts::Length for Forest<C> { fn len(&self) -> usize { self.len() } }
 
-    impl Forest<Terms> {
+    impl<C: FactColumn> Forest<C> {
         /// Forms a forest trie from a sequence of columns of identical lengths.
         ///
         /// This method takes ownership of the columns in order to drop them as they are processed.
-        /// It could be generalized to `Vec<C>` for any `C` that can be borrowed as `Terms` can be.
-        pub fn from_columns(columns: Vec<Terms>) -> Option<Self> {
+        pub fn from_columns(columns: Vec<C>) -> Option<Self> {
             for col in columns.iter() { assert_eq!(col.len(), columns[0].len()); }
             if columns.iter().any(|c| c.is_empty()) { return None; }
             let (mut groups, indexs): (Vec<_>, Vec<_>) = (0 .. columns.first().map(columnar::Len::len).unwrap_or(0)).map(|i| (0, i)).unzip();
@@ -139,14 +138,14 @@ pub mod terms {
                     values: column.borrow(),
                 };
                 // TODO: Figure out how to avoid `indexs` being literally just `0 .. len`.
-                Rc::new(Layer { list: Terms::sort(lists, &mut groups[..], &indexs[..], index == columns_len-1) })
+                Rc::new(Layer { list: C::sort(lists, &mut groups[..], &indexs[..], index == columns_len-1) })
             }).collect();
             Some(layers.try_into().expect("empty columns tested earlier"))
         }
     }
 
-    // Support methods for `<Forest<Terms> as FactContainer>::act_on`.
-    impl Forest<Terms> {
+    // Support methods for `<Forest<C> as FactContainer>::act_on`.
+    impl<C: FactColumn> Forest<C> {
         /// Filters `self` to facts satisfying literal and inter-column equalities.
         ///
         /// The argument `lit_filters` names columns and a literal they must equal, and `var_filters`
@@ -177,7 +176,7 @@ pub mod terms {
                     Ok(idx) => {
                         // naively start from all items at layer `idx`; could optimize to the active subset at the time.
                         let mut bounds = (0 .. self.layers[idx].list.values.len()).map(|i| (i, i+1)).collect::<Vec<_>>();
-                        crate::facts::trie::advance_bounds::<Terms>(&self.borrow()[idx+1..col+1], &mut bounds);
+                        crate::facts::trie::advance_bounds::<C>(&self.borrow()[idx+1..col+1], &mut bounds);
 
                         let mut active_peek = active.iter().copied().peekable();
                         let aligned = bounds.iter().enumerate().flat_map(|(i,(l,u))| {
@@ -187,13 +186,13 @@ pub mod terms {
                             std::iter::repeat(i).take(count)
                         }).collect::<Vec<_>>();
 
-                        crate::facts::trie::layers::filter_items::<Terms>(self.layers[col].borrow(), &mut active, self.layers[idx].list.values.borrow(), &aligned[..]);
+                        C::filter(self.layers[col].borrow(), &mut active, self.layers[idx].list.values.borrow(), &aligned[..]);
                     }
                     Err(lit) => {
-                        let mut literal = Lists::<Terms>::default();
-                        use columnar::Push; literal.push([lit]);
+                        let mut literal = C::default();
+                        C::push_literal(&mut literal, lit);
                         let aligned = std::iter::repeat(0).take(active.len()).collect::<Vec<_>>();
-                        crate::facts::trie::layers::filter_items::<Terms>(self.layers[col].borrow(), &mut active, literal.values.borrow(), &aligned[..])
+                        C::filter(self.layers[col].borrow(), &mut active, literal.borrow(), &aligned[..])
                     }
                 }
             }
@@ -217,7 +216,7 @@ pub mod terms {
         #[inline(never)]
         fn permute(&self, projection: &[usize], thresh: usize) -> Self {
             let indexs = (0 .. self.layers[0].list.len()).collect::<Vec<_>>();
-            permute_subset(&self.borrow()[..], projection, &indexs, thresh).try_into().expect("permutation should not remove facts")
+            permute_subset::<C>(&self.borrow()[..], projection, &indexs, thresh).try_into().expect("permutation should not remove facts")
         }
         /// Introduces repeated and literal columns.
         ///
@@ -234,19 +233,21 @@ pub mod terms {
                         if first_pos == pos { self.layers.pop().unwrap() }
                         else {  // create a copy of this column at the end of `layers`.
                             let mut bounds = (0 .. self.layers[*col].list.values.len()).map(|i| (i,i+1)).collect::<Vec<_>>();
-                            for layer in self.layers[*col..].iter().skip(1) { crate::facts::trie::layers::advance_bounds::<Terms>(layer.borrow(), &mut bounds[..]); }
-                            let mut list = Lists::<Terms>::default();
+                            for layer in self.layers[*col..].iter().skip(1) { crate::facts::trie::layers::advance_bounds::<C>(layer.borrow(), &mut bounds[..]); }
+                            let mut values = C::default();
                             for (index, (lower, upper)) in bounds.into_iter().enumerate() {
-                                for _ in lower .. upper { use columnar::Push; list.push([self.layers[*col].list.values.borrow().get(index)]); }
+                                for _ in lower .. upper { values.push(self.layers[*col].list.values.borrow().get(index)); }
                             }
-                            Rc::new(Layer { list })
+                            let bounds = columnar::primitive::offsets::Strides::new(1, values.len() as u64);
+                            Rc::new(Layer { list: columnar::Vecs { bounds, values } })
                         }
                     },
                     Err(lit) => {
                         let count = self.layers.last().map(|l| l.list.values.len()).unwrap_or(1);
-                        let mut list = Lists::<Terms>::default();
-                        for _ in 0 .. count { use columnar::Push; list.push([lit]); }
-                        Rc::new(Layer { list })
+                        let mut values = C::default();
+                        for _ in 0 .. count { C::push_literal(&mut values, lit); }
+                        let bounds = columnar::primitive::offsets::Strides::new(1, count as u64);
+                        Rc::new(Layer { list: columnar::Vecs { bounds, values } })
                     },
                 });
             }
@@ -257,7 +258,7 @@ pub mod terms {
 
     /// Produces columns in the order indicated by `projection`, for the subset of indexes in `indexs`.
     #[inline(never)]
-    fn permute_subset(layers: &[<Lists<Terms> as Borrow>::Borrowed<'_>], projection: &[usize], indexs: &[usize], thresh: usize) -> Vec<Rc<Layer<Terms>>> {
+    fn permute_subset<C: FactColumn>(layers: &[<Lists<C> as Borrow>::Borrowed<'_>], projection: &[usize], indexs: &[usize], thresh: usize) -> Vec<Rc<Layer<C>>> {
 
         for index in 1 .. layers.len() { assert_eq!(layers[index-1].values.len(), layers[index].len()); }
 
@@ -271,10 +272,10 @@ pub mod terms {
 
             let mut bounds = indexs.iter().copied().map(|i| (i,i+1)).collect::<Vec<_>>();
             for layer in 0 .. prefix {
-                let mut out_layer = <Lists::<Terms> as Container>::with_capacity_for([layers[layer]].into_iter());
+                let mut out_layer = <Lists::<C> as Container>::with_capacity_for([layers[layer]].into_iter());
                 for (lower, upper) in bounds.iter().copied() { out_layer.extend_from_self(layers[layer], lower .. upper); }
                 output.push(Rc::new(Layer { list: out_layer }));
-                crate::facts::trie::layers::advance_bounds::<Terms>(layers[layer], &mut bounds);
+                crate::facts::trie::layers::advance_bounds::<C>(layers[layer], &mut bounds);
             }
 
             // If columns remain, we should reform the input and call into `permute_subset_inner`.
@@ -283,19 +284,19 @@ pub mod terms {
                 let projection2 = projection[prefix..].iter().map(|c| *c - prefix).collect::<Vec<_>>();
                 let indexs2 = bounds.iter().copied().flat_map(|(l,u)| l..u).collect::<Vec<_>>();
                 let groups = (0 .. indexs2.len()).collect::<Vec<_>>();
-                output.extend(permute_subset_scale(layers2, &projection2, &groups, &indexs2, thresh));
+                output.extend(permute_subset_scale::<C>(layers2, &projection2, &groups, &indexs2, thresh));
             }
 
             output
         }
         else {
             let groups = (0 .. indexs.len()).collect::<Vec<_>>();
-            permute_subset_scale(layers, projection, &groups, indexs, thresh)
+            permute_subset_scale::<C>(layers, projection, &groups, indexs, thresh)
         }
     }
 
     /// A trampoline for permutation, that prepares the work we have to do in the event that it is too much to do at once.
-    fn permute_subset_scale(layers: &[<Lists<Terms> as Borrow>::Borrowed<'_>], projection: &[usize], groups: &[usize], starts: &[usize], thresh: usize) -> Vec<Rc<Layer<Terms>>> {
+    fn permute_subset_scale<C: FactColumn>(layers: &[<Lists<C> as Borrow>::Borrowed<'_>], projection: &[usize], groups: &[usize], starts: &[usize], thresh: usize) -> Vec<Rc<Layer<C>>> {
 
         // There are many ways the incoming `[(group, start)]` asks can be overwhelming.
         // We'll handle one common special case first, to try and learn a bit about how to do this efficiently.
@@ -305,36 +306,37 @@ pub mod terms {
 
             // Establish advance bounds, groups, starts.
             let mut bounds = starts.iter().map(|i| (*i, i+1)).collect::<Vec<_>>();
-            crate::facts::trie::advance_bounds::<Terms>(&layers[..1], &mut bounds);
+            crate::facts::trie::advance_bounds::<C>(&layers[..1], &mut bounds);
             let mut new_groups: Vec<usize> = Vec::with_capacity(bounds.iter().map(|(l,u)| u-l).sum());
             let mut new_starts: Vec<usize> = Vec::with_capacity(bounds.iter().map(|(l,u)| u-l).sum());
             new_groups.extend(bounds.iter().copied().zip(groups.iter()).flat_map(|((l,u),g)| std::iter::repeat(*g).take(u-l)));
             new_starts.extend(bounds.iter().copied().flat_map(|(l,u)| l .. u));
 
             // Convert the first layer from 1:m to 1:1.
+            // Reborrow the layers to the local lifetime, so that `stride` can be installed.
             let values = layers.last().unwrap().values.len() as u64;
             let stride = columnar::primitive::offsets::Strides::new(1, values);
-            let mut layers = layers.to_vec();
+            let mut layers = layers.iter().map(|x| <Lists<C> as Borrow>::reborrow(*x)).collect::<Vec<_>>();
             layers[0].bounds = stride.borrow();
 
             // Establish sizes of each new start.
             let mut new_bounds = new_starts.iter().map(|i| (*i,i+1)).collect::<Vec<_>>();
-            crate::facts::trie::advance_bounds::<Terms>(&layers[1..], &mut new_bounds);
+            crate::facts::trie::advance_bounds::<C>(&layers[1..], &mut new_bounds);
 
-            let mut merged: FactLSM<Forest<Terms>> = FactLSM::default();
+            let mut merged: FactLSM<Forest<C>> = FactLSM::default();
             let mut cursor = 0;
             while cursor < new_starts.len() {
                 let mut count = 0;
                 let finger = cursor;
                 while cursor < new_bounds.len() && count < thresh { count += new_bounds[cursor].1 - new_bounds[cursor].0; cursor += 1; }
-                let layers = permute_subset_inner(&layers, projection, &new_groups[finger .. cursor], &new_starts[finger .. cursor]);
+                let layers = permute_subset_inner::<C>(&layers, projection, &new_groups[finger .. cursor], &new_starts[finger .. cursor]);
                 merged.push(layers.try_into().unwrap());
             }
 
             merged.flatten().unwrap().layers
 
         }
-        else { permute_subset_inner(layers, projection, groups, starts) }
+        else { permute_subset_inner::<C>(layers, projection, groups, starts) }
     }
 
     /// Permutes the columns of `layers` to match `projection`, while subsetting by `starts` and grouping by `groups`.
@@ -342,7 +344,7 @@ pub mod terms {
     /// The `layers` argument describes a collection of facts with as many columns as there are layers, numbered in that order.
     /// The `projection` argument articulates the intended subset and output order of those columns,
     #[inline(never)]
-    fn permute_subset_inner(layers: &[<Lists<Terms> as Borrow>::Borrowed<'_>], projection: &[usize], groups: &[usize], starts: &[usize]) -> Vec<Rc<Layer<Terms>>> {
+    fn permute_subset_inner<C: FactColumn>(layers: &[<Lists<C> as Borrow>::Borrowed<'_>], projection: &[usize], groups: &[usize], starts: &[usize]) -> Vec<Rc<Layer<C>>> {
 
         // Informally, the plan is to move through `projection`, repeatedly taking the next layer index, and then all layer indexes less or equal to it.
         // The less-or-equal layers each provide exactly one value for each position in the "next" layer, and call for different logic than that layer.
@@ -371,12 +373,12 @@ pub mod terms {
 
             // First, find the ranges of item identifiers in layer `groups_list_layer`, by projecting forward.
             let mut idents = starts.iter().copied().map(|i| (i,i+1)).collect::<Vec<_>>();
-            advance_bounds::<Terms>(&layers[..groups_list_layer], &mut idents);
+            advance_bounds::<C>(&layers[..groups_list_layer], &mut idents);
             // Next determine the number of repetitions needed for each group identifier, by projecting forward.
             assert_eq!(groups.len(), idents.iter().map(|(l,u)| u-l).sum());
             let mut bounds = Vec::with_capacity(groups.len());
             bounds.extend(idents.iter().copied().flat_map(|(l,u)| (l..u).map(|i| (i,i+1))));
-            advance_bounds::<Terms>(&layers[groups_list_layer .. col+1], &mut bounds);
+            advance_bounds::<C>(&layers[groups_list_layer .. col+1], &mut bounds);
             // Explicitly repeat each group identifier the appropriate number of times.
             let new_count = bounds.iter().copied().map(|(l,u)| u-l).sum();
             let mut new_groups = Vec::with_capacity(new_count);
@@ -387,7 +389,7 @@ pub mod terms {
             groups_list_layer = col+1;
 
             let last = projection_idx == projection.len() - 1;
-            result.push(Rc::new(Layer { list: Terms::sort(layers[col], &mut groups, &indexs, last) }));
+            result.push(Rc::new(Layer { list: C::sort(layers[col], &mut groups, &indexs, last) }));
 
             projection_idx += 1;
 
@@ -402,18 +404,18 @@ pub mod terms {
 
                 // First find the ranges of item identifiers in layer `col` we'll want to involve, by projecting forward.
                 let mut idents = starts.iter().copied().map(|i| (i,i+1)).collect::<Vec<_>>();
-                advance_bounds::<Terms>(&layers[..col+1], &mut idents);
+                advance_bounds::<C>(&layers[..col+1], &mut idents);
                 // Next determine the number of repetitions needed for each individual identifier, by projecting forward.
                 let mut bounds = Vec::with_capacity(idents.iter().map(|(l,u)| u-l).sum());
                 bounds.extend(idents.iter().copied().flat_map(|(l,u)| (l..u).map(|i| (i,i+1))));
-                advance_bounds::<Terms>(&layers[col+1..groups_list_layer], &mut bounds);
+                advance_bounds::<C>(&layers[col+1..groups_list_layer], &mut bounds);
                 // Explicitly repeat each item identifier from layer `col` the appropriate number of times.
                 // The length of `indexs` does not increase, so we only need to clear it and refill it.
                 indexs.clear();
                 indexs.extend(idents.iter().copied().flat_map(|(l,u)| l..u).zip(bounds.iter().copied().map(|(l,u)| u-l)).flat_map(|(i,c)| std::iter::repeat(i).take(c)));
 
                 let last = projection_idx == projection.len() - 1;
-                result.push(Rc::new(Layer { list: Terms::sort(layers[col], &mut groups, &indexs, last) }));
+                result.push(Rc::new(Layer { list: C::sort(layers[col], &mut groups, &indexs, last) }));
 
                 projection_idx += 1;
             }
@@ -430,13 +432,13 @@ pub mod terms {
     /// Each projection should contain each column at most once. Repeated columns can be introduced afterwards,
     /// for example by the `Forest::embellish` method.
     #[inline(never)]
-    fn join_cols(
-        this: &[<Lists<Terms> as Borrow>::Borrowed<'_>],
-        thats: &[&[<Lists<Terms> as Borrow>::Borrowed<'_>]],
+    fn join_cols<'a, C: FactColumn>(
+        this: &[<Lists<C> as Borrow>::Borrowed<'a>],
+        thats: &[&[<Lists<C> as Borrow>::Borrowed<'a>]],
         arity: usize,
         projection: &[usize],
-        mut conduit: crate::comms::Conduit,
-    ) -> FactLSM<Forest<Terms>> {
+        mut conduit: crate::comms::Conduit<Forest<C>>,
+    ) -> FactLSM<Forest<C>> where Forest<C>: crate::comms::Exchangeable {
 
         let thresh = conduit.thresh();
 
@@ -449,15 +451,16 @@ pub mod terms {
         // TODO: This is a work-around due to arity 0 not working great due to edge cases.
         //       Should totally fix the logic below, but need to avoid `last().unwrap()`.
         if arity == 0 {
-            let mut unit: Lists<Terms> = Default::default();
-            let no_bytes: &[u8] = &[];
-            use columnar::Push;
-            unit.push(vec![no_bytes]);  //
-            let mut new_this = this.to_vec();
+            // One list of one placeholder item, whose value is never inspected.
+            let mut values = C::default();
+            C::push_literal(&mut values, &[]);
+            let unit: Lists<C> = columnar::Vecs { bounds: columnar::primitive::offsets::Strides::new(1, 1), values };
+            // Reborrow the inputs to the local lifetime, so that `unit` can join them.
+            let mut new_this = this.iter().map(|x| <Lists<C> as Borrow>::reborrow(*x)).collect::<Vec<_>>();
             new_this.insert(0, unit.borrow());
             let mut new_thats = Vec::with_capacity(thats.len());
             for that in thats {
-                let mut new_that = that.to_vec();
+                let mut new_that = that.iter().map(|x| <Lists<C> as Borrow>::reborrow(*x)).collect::<Vec<_>>();
                 new_that.insert(0, unit.borrow());
                 new_thats.push(new_that);
             }
@@ -475,7 +478,7 @@ pub mod terms {
             let mut this_aligned = Vec::new();
             for other in 0 .. thats.len() {
                 let layer1 = &thats[other][layer];
-                let results = Terms::intersect(*layer0, *layer1, &aligned[other].0, &aligned[other].1);
+                let results = C::intersect(*layer0, *layer1, &aligned[other].0, &aligned[other].1);
                 this_aligned.extend_from_slice(&results.0);
                 aligned[other] = (Rc::new(results.0), Rc::new(results.1));
             }
@@ -493,12 +496,12 @@ pub mod terms {
         let mut this_order = Vec::default();
         for col in projection.iter().copied() { if arity <= col && col < this.len() && !this_order.contains(&(col - arity)) { this_order.push(col - arity); } }
         if this_order != (0 .. this_order.len()).collect::<Vec<_>>() {
-            let layers = permute_subset(&this[arity..], &this_order[..], &this_i[..], thresh);
+            let layers = permute_subset::<C>(&this[arity..], &this_order[..], &this_i[..], thresh);
             this_values = Some(Forest { layers });
             let this_i = Rc::make_mut(&mut this_i);
             for i in 0 .. this_i.len() { this_i[i] = i; }
         }
-        let this_values = this_values.as_ref().map(|x| x.borrow()).unwrap_or(this[arity..].to_vec());
+        let this_values = this_values.as_ref().map(|x| x.borrow()).unwrap_or_else(|| this[arity..].iter().map(|x| <Lists<C> as Borrow>::reborrow(*x)).collect());
 
         // Produce `that_j` and `that_values`, indexes into columns in the order they appear in `projection`.
         // We'll default to the indexes and layers of `thats[0]`, and override them if more thats, or if the projection is non-trivial.
@@ -510,10 +513,10 @@ pub mod terms {
             let thats_values = thats.iter().map(|t| &t[arity..]).collect::<Vec<_>>();
             let thats_groups = aligned.iter().map(|(i,_)| &i[..]).collect::<Vec<_>>();
             let thats_indexs = aligned.iter().map(|(_,j)| &j[..]).collect::<Vec<_>>();
-            that_values = Some( Forest { layers: restrict_project_merge(&thats_values, &thats_groups, &thats_indexs, &that_order, thresh).unwrap() });
+            that_values = Some( Forest { layers: restrict_project_merge::<C>(&thats_values, &thats_groups, &thats_indexs, &that_order, thresh).unwrap() });
             let that_j = Rc::make_mut(&mut that_j); that_j.clear(); that_j.extend(0 .. this_i.len());
         }
-        let that_values = that_values.as_ref().map(|x| x.borrow()).unwrap_or(thats[0][arity..].to_vec());
+        let that_values = that_values.as_ref().map(|x| x.borrow()).unwrap_or_else(|| thats[0][arity..].iter().map(|x| <Lists<C> as Borrow>::reborrow(*x)).collect());
 
         // At this point we can see the work we have to do, and may want to stage it to avoid doing everything at once.
         // We'll scan forward from `this_i` and `that_j` to assess the cardinality we'll produce, and only peel off as
@@ -527,13 +530,13 @@ pub mod terms {
         // We will reference this in determining how many aligned indexes to pull off at a time.
         let counts = {
             let mut this_bounds = aligned.0.iter().map(|i| (*i,*i+1)).collect::<Vec<_>>();
-            crate::facts::trie::advance_bounds::<Terms>(&this_values[..], &mut this_bounds[..]);
+            crate::facts::trie::advance_bounds::<C>(&this_values[..], &mut this_bounds[..]);
             let mut that_bounds = aligned.1.iter().map(|j| (*j,*j+1)).collect::<Vec<_>>();
-            crate::facts::trie::advance_bounds::<Terms>(&that_values[..], &mut that_bounds[..]);
+            crate::facts::trie::advance_bounds::<C>(&that_values[..], &mut that_bounds[..]);
             this_bounds.iter().zip(that_bounds.iter()).map(|((l0,u0),(l1,u1))| (u0-l0) * (u1-l1)).collect::<Vec<_>>()
         };
 
-        let mut output_lsm: FactLSM<Forest<Terms>> = Default::default();
+        let mut output_lsm: FactLSM<Forest<C>> = Default::default();
         let mut aligned_pos = 0;
         while aligned_pos < counts.len() {
 
@@ -572,13 +575,13 @@ pub mod terms {
 
                     // First, let's determine the counts for each of `this` and `that` at `aligned`.
                     let mut this_bounds = aligned.0[aligned_prev .. aligned_pos].iter().map(|i| (*i,*i+1)).collect::<Vec<_>>();
-                    crate::facts::trie::advance_bounds::<Terms>(&this_values[0 .. this_cursor], &mut this_bounds[..]);
+                    crate::facts::trie::advance_bounds::<C>(&this_values[0 .. this_cursor], &mut this_bounds[..]);
                     let mut that_bounds = aligned.1[aligned_prev .. aligned_pos].iter().map(|j| (*j,*j+1)).collect::<Vec<_>>();
-                    crate::facts::trie::advance_bounds::<Terms>(&that_values[0 .. that_cursor], &mut that_bounds[..]);
+                    crate::facts::trie::advance_bounds::<C>(&that_values[0 .. that_cursor], &mut that_bounds[..]);
 
                     // Now let's project forward from `both_need[column]`.
                     let mut bounds = aligneds[column].iter().map(|i| (*i,*i+1)).collect::<Vec<_>>();
-                    crate::facts::trie::advance_bounds::<Terms>(&this[column+1 .. arity], &mut bounds);
+                    crate::facts::trie::advance_bounds::<C>(&this[column+1 .. arity], &mut bounds);
 
                     let mut products = this_bounds.iter().zip(that_bounds.iter()).map(|((l0,u0), (l1,u1))| (u0-l0)*(u1-l1))
                                                         .zip(old_aligned.iter().copied()).peekable();
@@ -593,7 +596,7 @@ pub mod terms {
                     // Flatten the (index, count) into repetitions.
                     let mut flat = Vec::with_capacity(groups.len());
                     flat.extend(aligneds[column].iter().zip(counts).flat_map(|(i,c)| std::iter::repeat(*i).take(c)));
-                    Terms::sort(this[column], &mut groups, &flat, last)
+                    C::sort(this[column], &mut groups, &flat, last)
                 }
                 else if column < this.len() {
                     // We expect this to be the next column in `this_values`.
@@ -602,8 +605,8 @@ pub mod terms {
 
                     // Expand `this_i`, and corresponding repetitions in `groups` and `that_j`.
                     let mut others = if that_cursor < that_values.len() { vec![&mut groups, Rc::make_mut(&mut that_j)] } else { vec![&mut groups] };
-                    expand(Rc::make_mut(&mut this_i), values, &mut others);
-                    Terms::sort(values, &mut groups, &this_i, last)
+                    expand::<C>(Rc::make_mut(&mut this_i), values, &mut others);
+                    C::sort(values, &mut groups, &this_i, last)
                 }
                 else if column < this.len() + arity { unimplemented!("reference equated column of first join argument") }
                 else {
@@ -613,8 +616,8 @@ pub mod terms {
 
                     // Expand `that_j`, and corresponding repetitions in `groups` and `this_i`.
                     let mut others = if this_cursor < this_values.len() { vec![&mut groups, Rc::make_mut(&mut this_i)] } else { vec![&mut groups] };
-                    expand(Rc::make_mut(&mut that_j), values, &mut others);
-                    Terms::sort(values, &mut groups, &that_j, last)
+                    expand::<C>(Rc::make_mut(&mut that_j), values, &mut others);
+                    C::sort(values, &mut groups, &that_j, last)
                 };
                 Rc::new(Layer { list })
             }).collect::<Vec<_>>();
@@ -630,13 +633,13 @@ pub mod terms {
     ///
     /// The first layer of the result should have as many lists as there are distinct values of `group`, with the implied correspondence.
     #[inline(never)]
-    fn restrict_project_merge<'a>(
-        layers: &[&[<Lists<Terms> as Borrow>::Borrowed<'a>]],
+    fn restrict_project_merge<'a, C: FactColumn>(
+        layers: &[&[<Lists<C> as Borrow>::Borrowed<'a>]],
         groups: &[&[usize]],
         indexs: &[&[usize]],
         projection: &[usize],
         thresh: usize,
-    ) -> Option<Vec<Rc<Layer<Terms>>>> {
+    ) -> Option<Vec<Rc<Layer<C>>>> {
 
         // Assert intended preconditions.
         assert!(!layers.is_empty());
@@ -653,16 +656,16 @@ pub mod terms {
         if indexs.is_empty() { return None; }
 
         // TODO: can union from indexed layers without having to copy first.
-        if layers.len() == 1 { Some(permute_subset(layers[0], projection, indexs[0], thresh)) }
+        if layers.len() == 1 { Some(permute_subset::<C>(layers[0], projection, indexs[0], thresh)) }
         else {
-            let mut extracted: FactLSM<Forest<Terms>> = FactLSM::default();
+            let mut extracted: FactLSM<Forest<C>> = FactLSM::default();
             for index in 0 .. layers.len() {
                 if !groups[index].is_empty() {
-                    let mut layers = permute_subset(layers[index], projection, indexs[index], thresh);
-                    let mut base: Layer<Terms> = Default::default();
-                    use columnar::Push;
+                    let mut layers = permute_subset::<C>(layers[index], projection, indexs[index], thresh);
+                    let mut base: Layer<C> = Default::default();
                     // TODO: rework layers to allow this to be something akin to `&groups[index]` without the copy.
-                    base.list.values.extend(groups[index].iter().map(|g| (*g as u32).to_be_bytes()));
+                    // The group identifiers are a synthetic column, encoded as 4-byte literals.
+                    for g in groups[index].iter() { C::push_literal(&mut base.list.values, &(*g as u32).to_be_bytes()); }
                     base.list.bounds.push(groups[index].len() as u64);
                     layers.insert(0, Rc::new(base));
                     extracted.layers.push(layers.try_into().expect("guarded by !groups[index].is_empty()"));
@@ -683,7 +686,7 @@ pub mod terms {
     /// In principle the explicit representation of the ranges and repetitions could be avoided, by updating `index` and reporting the range lengths.
     /// This would avoid resizing any of the vectors, only rewriting `index`, and pushing the work of unpacking any until later when actually needed.
     #[inline(never)]
-    fn expand<'a>(index: &mut Vec<usize>, lists: <Lists<Terms> as Borrow>::Borrowed<'a>, others: &mut [&mut Vec<usize>]) {
+    fn expand<'a, C: FactColumn>(index: &mut Vec<usize>, lists: <Lists<C> as Borrow>::Borrowed<'a>, others: &mut [&mut Vec<usize>]) {
 
         // Map out the number of repetitions for each position, and tally the total for pre-allocation.
         let mut total = 0;
@@ -706,7 +709,7 @@ pub mod terms {
         }
     }
 
-    impl FactContainer for Forest<Terms> {
+    impl<C: FactColumn> FactContainer for Forest<C> where Forest<C>: crate::comms::Exchangeable {
 
         #[inline(never)]
         fn act_on(&self, action: &Action<Vec<u8>>, thresh: usize) -> FactLSM<Self> {
@@ -739,7 +742,7 @@ pub mod terms {
             result.into()
         }
 
-        fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projection: &[usize], conduit: crate::comms::Conduit) -> FactLSM<Self> {
+        fn join_many<'a>(&'a self, others: impl Iterator<Item = &'a Self>, arity: usize, projection: &[usize], conduit: crate::comms::Conduit<Self>) -> FactLSM<Self> {
             let others = others.map(|o| o.borrow()).collect::<Vec<_>>();
             let others = others.iter().map(|o| &o[..]).collect::<Vec<_>>();
             join_cols(&self.borrow()[..], &others[..], arity, projection, conduit)
@@ -750,7 +753,7 @@ pub mod terms {
         #[inline(never)] fn semijoin<'a>(self, others: impl Iterator<Item = &'a Self>) -> FactLSM<Self> where Self: 'a { self.retain_join::<'a>(others, true) }
     }
 
-    impl Forest<Terms> {
+    impl<C: FactColumn> Forest<C> {
         /// Produces elements in `self` based on their presence in any of `others`.
         ///
         /// The `semi` argument controls whether this performs a semijoin or an antijoin,
@@ -764,7 +767,7 @@ pub mod terms {
         }
 
         #[inline(never)]
-        pub fn retain_inner<'a>(self, others: impl Iterator<Item = &'a [<Lists<Terms> as Borrow>::Borrowed<'a>]>, semi: bool) -> FactLSM<Self> {
+        pub fn retain_inner<'a, 'b>(self, others: impl Iterator<Item = &'b [<Lists<C> as Borrow>::Borrowed<'a>]>, semi: bool) -> FactLSM<Self> where 'a: 'b {
 
             use std::collections::VecDeque;
 
@@ -781,7 +784,7 @@ pub mod terms {
             for other in others.iter() {
                 let mut reports = (vec![0], vec![0]);
                 for (layer0, layer1) in self.layers.iter().zip(other.iter()) {
-                    reports = Terms::intersect(layer0.borrow(), *layer1, &reports.0, &reports.1);
+                    reports = C::intersect(layer0.borrow(), <Lists<C> as Borrow>::reborrow(*layer1), &reports.0, &reports.1);
                 }
                 // Mark shared paths appropriately.
                 for index in reports.0.iter().copied() { include[index] = semi; }
@@ -887,7 +890,7 @@ pub mod layers {
     /// `retain_items`, `col_sort`), each one line. The `Terms` implementation instead
     /// inspects the data for fixed widths, and dispatches to kernels specialized to those
     /// widths.
-    pub trait FactColumn: Container + Clone {
+    pub trait FactColumn: Container + Clone + std::fmt::Debug {
         /// Sorts the items of `lists` at `indexs` subject to the grouping/ordering of `groups`.
         ///
         /// Mints a new item for each distinct `(group, item)` pair and a new list for each
@@ -901,6 +904,14 @@ pub mod layers {
         fn retain_lists(lists: <Lists<Self> as Borrow>::Borrowed<'_>, bounds: &mut [(usize, usize)]) -> Lists<Self>;
         /// Retains items indicated by `retain`, which is refilled with per-list bools.
         fn retain_items(lists: <Lists<Self> as Borrow>::Borrowed<'_>, retain: &mut VecDeque<bool>) -> Lists<Self>;
+        /// Restricts `active` to item indexes that equal the corresponding element of `other[aligned]`.
+        fn filter<'a>(lists: <Lists<Self> as Borrow>::Borrowed<'a>, active: &mut Vec<usize>, other: Self::Borrowed<'a>, aligned: &[usize]);
+        /// Appends one item to `column`, decoded from a byte literal.
+        ///
+        /// Literals arrive as bytes from parsed rules and actions, and each container
+        /// decides how to decode them. The empty literal must be accepted, as it is
+        /// used for placeholder items whose values are never inspected.
+        fn push_literal(column: &mut Self, literal: &[u8]);
     }
 
     /// Byte strings, specialized at runtime to fixed-width kernels when widths allow.
@@ -949,6 +960,13 @@ pub mod layers {
                 Some(4) => { downgrade(retain_items(upgrade::<4>(lists).unwrap(), retain)) }
                 _______ => { retain_items(lists, retain) }
             }
+        }
+        fn filter<'a>(lists: <Lists<Terms> as Borrow>::Borrowed<'a>, active: &mut Vec<usize>, other: <Terms as Borrow>::Borrowed<'a>, aligned: &[usize]) {
+            filter_items::<Terms>(lists, active, other, aligned)
+        }
+        fn push_literal(column: &mut Terms, literal: &[u8]) {
+            use columnar::Push;
+            column.push(literal);
         }
     }
 

--- a/src/facts/trie.rs
+++ b/src/facts/trie.rs
@@ -912,6 +912,11 @@ pub mod layers {
         /// decides how to decode them. The empty literal must be accepted, as it is
         /// used for placeholder items whose values are never inspected.
         fn push_literal(column: &mut Self, literal: &[u8]);
+        /// A routing key for an item, used to shard facts among workers.
+        ///
+        /// The key must be a function of the item's value alone, so that equal items
+        /// route identically on all workers. It is reduced modulo the number of workers.
+        fn route(item: Self::Ref<'_>) -> u64;
     }
 
     /// Byte strings, specialized at runtime to fixed-width kernels when widths allow.
@@ -967,6 +972,9 @@ pub mod layers {
         fn push_literal(column: &mut Terms, literal: &[u8]) {
             use columnar::Push;
             column.push(literal);
+        }
+        fn route(item: <Terms as Borrow>::Ref<'_>) -> u64 {
+            *item.as_slice().last().unwrap() as u64
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,7 @@ fn handle_command(text: &str, state: &mut types::State, bytes: &mut BTreeMap<Vec
                     // single-process mode (peers() == 1). Useful at the top of
                     // a script before the first `.time` measurement, to absorb
                     // ssh/startup skew across processes.
-                    let mut empty = datatoad::facts::FactLSM::default();
+                    let mut empty = datatoad::facts::FactLSM::<datatoad::facts::FactCollection>::default();
                     state.comms.broadcast(&mut empty);
                 }
                 ".time" => {

--- a/src/rules/atoms/data.rs
+++ b/src/rules/atoms/data.rs
@@ -29,7 +29,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
 
         use columnar::Len;
         use crate::facts::trie::layers::advance_bounds;
-        use crate::facts::trie::layers::terms::intersection;
+        use crate::facts::FactColumn;
 
         let (other_facts, other_terms, _other_recent) = self;
 
@@ -58,7 +58,7 @@ impl<T: Ord + Clone + std::fmt::Debug> ExecAtom<T> for (Vec<Forest<Terms>>, Vec<
                 for other_part in other_facts.iter() {
                     let mut delta_idxs = vec![0];
                     let mut other_idxs = vec![0];
-                    for layer in 0 .. prefix { (delta_idxs, other_idxs) = intersection(delta.layer(layer).borrow(), other_part.layer(layer).borrow(), &delta_idxs, &other_idxs); }
+                    for layer in 0 .. prefix { (delta_idxs, other_idxs) = Terms::intersect(delta.layer(layer).borrow(), other_part.layer(layer).borrow(), &delta_idxs, &other_idxs); }
                     // The count derives from projecting `other_idxs` forward through `terms`.
                     let mut ranges = other_idxs.iter().map(|i| (*i,*i+1)).collect::<Vec<_>>();
                     for layer in prefix .. (prefix + terms.len()) { advance_bounds::<Terms>(other_part.layer(layer).borrow(), &mut ranges); }

--- a/tests/forest_model.rs
+++ b/tests/forest_model.rs
@@ -1,0 +1,196 @@
+//! Model-based tests for `Forest` operations.
+//!
+//! Each operation is checked against a transparent model: facts as a
+//! `BTreeSet<Vec<Vec<u8>>>`, with merge as set union, `act_on` as a
+//! map/filter over tuples, join as a nested loop, and semi/antijoin as
+//! retains by prefix.
+//!
+//! Data comes in two width regimes: uniform four-byte terms, which drive
+//! the width-specialized (`upgrade`) kernel paths, and mixed-width terms,
+//! which drive the generic fallback kernels. Both check against the same
+//! oracles.
+
+use std::collections::BTreeSet;
+
+use columnar::{Borrow, Index, Len, Push};
+use datatoad::comms::Comms;
+use datatoad::facts::{FactContainer, FactLSM, Forest, Merge, Terms};
+use datatoad::types::Action;
+
+type Fact = Vec<Vec<u8>>;
+type Model = BTreeSet<Fact>;
+
+/// A deterministic pseudo-random number generator.
+fn lcg(seed: u64) -> impl FnMut() -> u64 {
+    let mut state = seed.wrapping_mul(2) + 1;
+    move || {
+        state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+        state >> 33
+    }
+}
+
+/// Tuples of uniformly four-byte terms, from a small domain to force duplicates.
+fn fixed_tuples(count: usize, arity: usize, seed: u64) -> Vec<Fact> {
+    let mut next = lcg(seed);
+    (0..count).map(|_| (0..arity).map(|_| (next() as u32 % 64).to_be_bytes().to_vec()).collect()).collect()
+}
+
+/// Tuples of mixed-width terms (lengths zero through four), from a small domain.
+fn mixed_tuples(count: usize, arity: usize, seed: u64) -> Vec<Fact> {
+    let mut next = lcg(seed);
+    (0..count).map(|_| (0..arity).map(|_| {
+        let len = (next() % 5) as usize;
+        (0..len).map(|_| (next() % 4) as u8).collect()
+    }).collect()).collect()
+}
+
+fn forest(tuples: &[Fact]) -> Forest<Terms> {
+    let arity = tuples[0].len();
+    let mut cols = vec![Terms::default(); arity];
+    for tuple in tuples.iter() {
+        assert_eq!(tuple.len(), arity);
+        for (col, term) in tuple.iter().enumerate() { cols[col].push(&term[..]); }
+    }
+    Forest::from_columns(cols).unwrap()
+}
+
+fn model(tuples: &[Fact]) -> Model { tuples.iter().cloned().collect() }
+
+/// Extracts the facts of a forest by walking its layers.
+fn extract(forest: &Forest<Terms>) -> Model {
+    let mut paths: Vec<(Fact, usize)> = vec![(Vec::new(), 0)];
+    for layer in 0..forest.arity() {
+        let lists = forest.layer(layer).list.borrow();
+        let mut next = Vec::with_capacity(paths.len());
+        for (prefix, list) in paths {
+            let (lower, upper) = lists.bounds.bounds(list);
+            for item in lower..upper {
+                let mut path = prefix.clone();
+                path.push(lists.values.get(item).as_slice().to_vec());
+                next.push((path, item));
+            }
+        }
+        paths = next;
+    }
+    let facts: Model = paths.into_iter().map(|(path, _)| path).collect();
+    assert_eq!(facts.len(), forest.len(), "forest len disagrees with its distinct facts");
+    facts
+}
+
+fn extract_lsm(mut lsm: FactLSM<Forest<Terms>>) -> Model {
+    lsm.flatten().as_ref().map(extract).unwrap_or_default()
+}
+
+/// The model form of `act_on`.
+fn act_on_model(facts: &Model, action: &Action<Vec<u8>>) -> Model {
+    facts.iter()
+        .filter(|t| action.lit_filter.iter().all(|(col, lit)| &t[*col] == lit))
+        .filter(|t| action.var_filter.iter().all(|group| group.iter().all(|col| t[*col] == t[group[0]])))
+        .map(|t| action.projection.iter().map(|p| match p { Ok(col) => t[*col].clone(), Err(lit) => lit.clone() }).collect())
+        .collect()
+}
+
+/// The model form of `join_many`: tuples agreeing with some other on the first
+/// `arity` terms, projected by column index into the concatenated tuple space.
+fn join_model(this: &Model, others: &Model, arity: usize, projection: &[usize]) -> Model {
+    let mut result = Model::default();
+    for x in this.iter() {
+        for y in others.iter() {
+            if x[..arity] == y[..arity] {
+                result.insert(projection.iter().map(|c| if *c < x.len() { x[*c].clone() } else { y[*c - x.len()].clone() }).collect());
+            }
+        }
+    }
+    result
+}
+
+/// The model form of semijoin (`semi: true`) and antijoin (`semi: false`).
+fn retain_model(this: &Model, others: &Model, semi: bool) -> Model {
+    let arity = others.iter().next().map(|t| t.len()).unwrap_or(0);
+    this.iter().filter(|t| others.contains(&t[..arity].to_vec()) == semi).cloned().collect()
+}
+
+/// Both width regimes, as (name, tuples) pairs for a given shape and seed.
+fn regimes(count: usize, arity: usize, seed: u64) -> Vec<(&'static str, Vec<Fact>)> {
+    vec![("fixed", fixed_tuples(count, arity, seed)), ("mixed", mixed_tuples(count, arity, seed))]
+}
+
+#[test]
+fn model_build_and_merge() {
+    for (name, xs) in regimes(500, 3, 1) {
+        let ys = match name { "fixed" => fixed_tuples(500, 3, 2), _ => mixed_tuples(500, 3, 2) };
+        let (fx, fy) = (forest(&xs), forest(&ys));
+        assert_eq!(extract(&fx), model(&xs), "{}: build", name);
+        let union: Model = model(&xs).union(&model(&ys)).cloned().collect();
+        assert_eq!(extract(&fx.merge(fy)), union, "{}: merge", name);
+    }
+}
+
+#[test]
+fn model_act_on() {
+    for (name, xs) in regimes(500, 3, 3) {
+        let fx = forest(&xs);
+        let mx = model(&xs);
+        let lit = xs[0][1].clone();
+        let absent = vec![0xFFu8; 3];
+
+        let actions = vec![
+            // Permutation with a repeated column and an introduced literal.
+            Action { lit_filter: vec![], var_filter: vec![], projection: vec![Ok(2), Ok(0), Ok(2), Err(lit.clone())], input_arity: 3 },
+            // Filter by a literal that has matches, and one that cannot.
+            Action { lit_filter: vec![(1, lit.clone())], var_filter: vec![], projection: vec![Ok(0), Ok(2)], input_arity: 3 },
+            Action { lit_filter: vec![(0, absent)], var_filter: vec![], projection: vec![Ok(0)], input_arity: 3 },
+            // Filter by inter-column equality.
+            Action { lit_filter: vec![], var_filter: vec![vec![0, 2]], projection: vec![Ok(1), Ok(0)], input_arity: 3 },
+            // Project away all columns but one, deduplicating heavily.
+            Action { lit_filter: vec![], var_filter: vec![], projection: vec![Ok(1)], input_arity: 3 },
+        ];
+        for (idx, action) in actions.iter().enumerate() {
+            let expected = act_on_model(&mx, action);
+            // A large threshold, and a small one to exercise the staged permutation paths.
+            for thresh in [1 << 20, 64] {
+                assert_eq!(extract_lsm(fx.act_on(action, thresh)), expected, "{}: action {} thresh {}", name, idx, thresh);
+            }
+        }
+    }
+}
+
+#[test]
+fn model_join_many() {
+    for (name, xs) in regimes(300, 2, 4) {
+        let (ys, zs) = match name {
+            "fixed" => (fixed_tuples(300, 2, 5), fixed_tuples(300, 2, 6)),
+            _ => (mixed_tuples(300, 2, 5), mixed_tuples(300, 2, 6)),
+        };
+        let (fx, fy, fz) = (forest(&xs), forest(&ys), forest(&zs));
+        let (mx, my, mz) = (model(&xs), model(&ys), model(&zs));
+
+        // Join on the first column, producing (key, x.1, y.1).
+        let mut comms = Comms::default();
+        let expected = join_model(&mx, &my, 1, &[0, 1, 3]);
+        assert_eq!(extract_lsm(fx.join_many([&fy].into_iter(), 1, &[0, 1, 3], comms.conduit())), expected, "{}: join", name);
+
+        // The same join against two others, whose union is the other relation.
+        let union: Model = my.union(&mz).cloned().collect();
+        let expected = join_model(&mx, &union, 1, &[0, 1, 3]);
+        assert_eq!(extract_lsm(fx.join_many([&fy, &fz].into_iter(), 1, &[0, 1, 3], comms.conduit())), expected, "{}: join two", name);
+
+        // A small memory budget, to exercise the staged output paths.
+        comms.set_mem_budget(64);
+        let expected = join_model(&mx, &my, 1, &[0, 1, 3]);
+        assert_eq!(extract_lsm(fx.join_many([&fy].into_iter(), 1, &[0, 1, 3], comms.conduit())), expected, "{}: join staged", name);
+    }
+}
+
+#[test]
+fn model_anti_semi_join() {
+    for (name, xs) in regimes(500, 2, 7) {
+        let keys = match name { "fixed" => fixed_tuples(50, 1, 8), _ => mixed_tuples(50, 1, 8) };
+        let fx = forest(&xs);
+        let fk = forest(&keys);
+        let (mx, mk) = (model(&xs), model(&keys));
+
+        assert_eq!(extract_lsm(fx.clone().semijoin([&fk].into_iter())), retain_model(&mx, &mk, true), "{}: semijoin", name);
+        assert_eq!(extract_lsm(fx.antijoin([&fk].into_iter())), retain_model(&mx, &mk, false), "{}: antijoin", name);
+    }
+}


### PR DESCRIPTION
A trait for columns of facts that means to abstract away the `[u8]`-specificity. The goal is to frame a constraint on the container type that would allow otherwise general columnar types, including ADTs and the like.