### PR TITLE
Drop DATATOAD_MEMORY env var; configure budget via -m only

### DIFF
--- a/src/comms.rs
+++ b/src/comms.rs
@@ -15,7 +15,7 @@ pub struct Comms {
     /// An incrementing channel identifier.
     count: usize,
     /// Cluster-wide budget for in-flight intermediate tuples (bytes).
-    /// Configurable via `-m`/`--memory` CLI flag or `DATATOAD_MEMORY` env var.
+    /// Configurable via the `-m`/`--memory` CLI flag.
     mem_budget: usize,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,8 +58,7 @@ fn main() {
         let matches = opts.parse(args).map_err(|e| e.to_string()).unwrap();
         let config = Config::from_matches(&matches).unwrap();
         let mem_budget = matches.opt_str("m")
-            .or_else(|| std::env::var("DATATOAD_MEMORY").ok())
-            .map(|s| parse_byte_size(&s).expect("invalid -m/DATATOAD_MEMORY value"))
+            .map(|s| parse_byte_size(&s).expect("invalid -m/--memory value"))
             .unwrap_or(datatoad::comms::DEFAULT_MEM_BUDGET);
         (config, mem_budget, matches.free)
     };


### PR DESCRIPTION
The in-flight tuple memory budget could be set two ways: the `-m`/`--memory` flag and a `DATATOAD_MEMORY` environment fallback. For a single run parameter that's the "two ways to do one thing" smell — and the flag is the better of the two: it surfaces in `--help` and in the process's argv, so a run is self-describing, where the env var was invisible ambient state.

Keep the flag, remove the env fallback. Updates the doc comment on `Comms::mem_budget` and the parse-error message accordingly.

## Testing

- `-m bogus` → panics with `invalid -m/--memory value`.
- `DATATOAD_MEMORY=bogus` → now ignored, clean exit (previously panicked).
- `-m 1G` → still accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)